### PR TITLE
log: fix a deadlock caused by conflicting lock order

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -452,9 +452,9 @@ impl Log {
 	pub fn end_record(&self, log: LogChange) -> Result<u64> {
 		assert!(log.record_id + 1 == self.next_record_id.load(Ordering::Relaxed));
 		let record_id = log.record_id;
+		let mut overlays = self.overlays.write();
 		let mut appending = self.appending.write();
 		let (index, values, bytes) = log.to_file(&mut appending.file)?;
-		let mut overlays = self.overlays.write();
 		let mut total_index = 0;
 		for (id, overlay) in index.into_iter() {
 			total_index += overlay.map.len();


### PR DESCRIPTION
This patch fixes a possible deadlock caused by conflicting lock order in src/log.rs:

|clear_logs|end_record|
|---|---|
|overlays.write()||
||appending.write()|
|appending.write()//deadlock!||
||overlays.write()//deadlock!|

The fix is to lift the `overlays.write()` above `appending.write()` in `end_record()`.