### PR TITLE
Value iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Compute `k`, find index page using first `n` bits. Search for a matching entry t
 If an insertion is attempted into a full index page a reindex is triggered. 
 Page size of 64 index entries trigger a reindex once load factor reaches about 50%. 
 
+### Iterate 
+Iteration on a whole collection value is possible but inefficient. Mainly for maintenance purpose.
+Current implementation do not work on Multipart values. // TODO change the Key of multipart not at start?
+
 ### Reindex
 When a collision can't be resolved, a new table is created with twice the capacity. Insertion is immediately continued to the new table. A background process is started that moves entries from the old table to the new. All queries during that process check both tables.
 


### PR DESCRIPTION
I was looking this afternoon if there was a way to get a value iterator over a column and started this branch.

This should be mainly for maintenance (and I wanted to use it for some small column to but other db could be use instead).

Things here should almost work except for the last value table where current format of value makes it difficult to distinguish multipart values from other value (in the other table we rely on the fact that we always got length followed by an included key to say that [0, 0] is a non initialized value).

So this implementation would require changes to multipart value (I don't want to iterate on index), my personal feeling is that it is probably not worth it, but I open this PR as a question in case this functionality could be interesting (can be close).