### PR TITLE
Update Dependencies, switch memmap to memmap2 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Key-value database for the blockchain"
 [dependencies]
 log = "0.4.8"
 parking_lot = "0.10"
-memmap = "0.7"
+memmap2 = "0.2"
 blake2-rfc = "0.2.18"
 libc = "0.2"
 crc32fast = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ description = "Key-value database for the blockchain"
 
 [dependencies]
 log = "0.4.8"
-parking_lot = "0.10"
+parking_lot = "0.11	"
 memmap2 = "0.2"
 blake2-rfc = "0.2.18"
 libc = "0.2"
 crc32fast = "1.2.0"
-rand = "0.7.3"
+rand = "0.8.2"
 hex = "0.4.2"
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.8.2"
 
 [profile.release]
 panic = "abort"

--- a/src/index.rs
+++ b/src/index.rs
@@ -121,7 +121,7 @@ pub enum PlanOutcome {
 
 pub struct IndexTable {
 	pub id: TableId,
-	map: RwLock<Option<memmap::MmapMut>>,
+	map: RwLock<Option<memmap2::MmapMut>>,
 	path: std::path::PathBuf,
 }
 
@@ -194,7 +194,7 @@ impl IndexTable {
 		};
 
 		file.set_len(file_size(id.index_bits()))?;
-		let map = unsafe { memmap::MmapMut::map_mut(&file)? };
+		let map = unsafe { memmap2::MmapMut::map_mut(&file)? };
 		log::debug!(target: "parity-db", "Opened existing index {}", id);
 		Ok(Some(IndexTable {
 			id,
@@ -228,7 +228,7 @@ impl IndexTable {
 		}
 	}
 
-	fn chunk_at(index: u64, map: &memmap::MmapMut) -> &[u8] {
+	fn chunk_at(index: u64, map: &memmap2::MmapMut) -> &[u8] {
 		let offset = META_SIZE + index as usize * CHUNK_LEN;
 		&map[offset .. offset + CHUNK_LEN]
 	}
@@ -379,7 +379,7 @@ impl IndexTable {
 			log::debug!(target: "parity-db", "Created new index {}", self.id);
 			//TODO: check for potential overflows on 32-bit platforms
 			file.set_len(file_size(self.id.index_bits()))?;
-			*wmap = Some(unsafe { memmap::MmapMut::map_mut(&file)? });
+			*wmap = Some(unsafe { memmap2::MmapMut::map_mut(&file)? });
 			map = parking_lot::RwLockWriteGuard::downgrade_to_upgradable(wmap);
 		}
 


### PR DESCRIPTION
refs https://github.com/paritytech/substrate/issues/7956

[Memmap is unmaintained](https://rustsec.org/advisories/RUSTSEC-2020-0077.html), fortunately a drop-in fork exists (memmap2). This PR switches the codebase to that crate and updates all dependencies to their latest version.

_Note_: as memmap is exposed in an external type, this change is a breaking major. Therefore, according to SemVer, the next version of this crate released should be `0.2.0` (at least).

_Note 2_: one main update that happened since the fork is [removing the winapi-dependency in favor of a localised equivialent](https://github.com/danburkert/memmap-rs/commit/37d18bbf421c4833c0f662f56889f83f7e72ad25).