### PR TITLE
Fix panic when asking for a salted hash of key with len != 32

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::VecDeque;
+use std::cmp::min;
 use std::sync::atomic::{AtomicU64, Ordering};
 use parking_lot::RwLock;
 use crate::{
@@ -145,8 +146,9 @@ impl Column {
 			k.copy_from_slice(&key[0..32]);
 		} else {
 			let mut salted = [0u8; 64];
+			let max_len = min(key.len(), 32);
 			salted[0..32].copy_from_slice(&self.salt);
-			salted[32..64].copy_from_slice(&key);
+			salted[32..(32 + max_len)].copy_from_slice(&key[..max_len]);
 			k.copy_from_slice(blake2_rfc::blake2b::blake2b(32, &[], &salted).as_bytes());
 		}
 		k


### PR DESCRIPTION
[When upgrading substrate to latest [parity-db 2.0.0`](https://github.com/paritytech/substrate/pull/8015), we [saw a panic in the benchmarking](https://gitlab.parity.io/parity/substrate/-/jobs/801118#L2252) of code we haven't touched. A short investigation revealed that the [recently added key salting feature](https://github.com/paritytech/parity-db/commit/64389057d3db2a72f92e43259db1a0ad65c66632) doesn't properly deal with keys of length other than `32`. This PR fixes that behavior for both circumstances of the key being smaller then (our case) but also larger than 32 character.

I wanted to add tests, but noticed there aren't any and that a general infrastructure for them is missing.. (e.g. easily create a testable `Column`)

@arkpar may I ask you to release this as `2.0.1` soon, so I can merge the dependencies PR?!?