### PR TITLE
Reindexing at restart

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -204,7 +204,7 @@ impl Column {
 		reindex.queue.push_back(old_table);
 	}
 
-	pub fn write_index_plan(&self, key: &Key, address: Address, log: &mut LogWriter) -> Result<PlanOutcome> {
+	pub fn write_reindex_plan(&self, key: &Key, address: Address, log: &mut LogWriter) -> Result<PlanOutcome> {
 		let tables = self.tables.upgradable_read();
 		let reindex = self.reindex.upgradable_read();
 		if Self::search_index(key, &tables.index, &*tables, log)?.is_some() {
@@ -214,7 +214,7 @@ impl Column {
 			PlanOutcome::NeedReindex => {
 				log::debug!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));
 				Self::trigger_reindex(tables, reindex, self.path.as_path());
-				self.write_index_plan(key, address, log)?;
+				self.write_reindex_plan(key, address, log)?;
 				return Ok(PlanOutcome::NeedReindex);
 			}
 			_ => {

--- a/src/column.rs
+++ b/src/column.rs
@@ -471,8 +471,15 @@ impl Column {
 						let mut key = Key::default();
 						// restore 16 high bits
 						&mut key[0..8].copy_from_slice(&index_key.to_be_bytes());
-						log::trace!(target: "parity-db", "{}: Reinserting {}", source.id, hex(&key));
-						plan.push((key, entry.address(source.id.index_bits())))
+						let address = entry.address(source.id.index_bits());
+						if let Some(partial_key) = tables.value[address.size_tier() as usize]
+							.partial_key_at(address.offset(), &*log.overlays())? {
+							&mut key[6..].copy_from_slice(&partial_key[6..]);
+							log::trace!(target: "parity-db", "{}: Reinserting {}", source.id, hex(&key));
+							plan.push((key, entry.address(source.id.index_bits())))
+						} else {
+							log::error!(target: "parity-db", "Missing value for reindexing {}, {}", source.id, hex(&key));
+						}
 					}
 					count += 1;
 					source_index += 1;

--- a/src/db.rs
+++ b/src/db.rs
@@ -151,8 +151,8 @@ impl DbInner {
 			flush_worker_cv: Condvar::new(),
 			flush_work: Mutex::new(false),
 			enact_mutex: Mutex::new(()),
-			next_reindex: AtomicU64::new(0),
-			last_enacted: AtomicU64::new(0),
+			next_reindex: AtomicU64::new(1),
+			last_enacted: AtomicU64::new(1),
 			collect_stats: options.stats,
 			bg_err: Mutex::new(None),
 			_lock_file: lock_file,
@@ -608,6 +608,8 @@ impl Db {
 	/// Open the database with given
 	pub fn open(options: &Options) -> Result<Db> {
 		let db = Arc::new(DbInner::open(options)?);
+		// This needs to be call before log thread: so first reindexing
+		// will run in correct state.
 		db.replay_all_logs()?;
 		let commit_worker_db = db.clone();
 		let commit_thread = std::thread::spawn(move ||
@@ -667,7 +669,8 @@ impl Db {
 	}
 
 	fn log_worker(db: Arc<DbInner>) -> Result<()> {
-		let mut more_work = false;
+		// Start with pending reindex.
+		let mut more_work = db.process_reindex()?;
 		while !db.shutdown.load(Ordering::SeqCst) {
 			if !more_work {
 				let mut work = db.log_work.lock();

--- a/src/db.rs
+++ b/src/db.rs
@@ -380,7 +380,7 @@ impl DbInner {
 					writer.record_id(),
 				);
 				for (key, address) in batch.into_iter() {
-					match column.write_index_plan(&key, address, &mut writer)? {
+					match column.write_reindex_plan(&key, address, &mut writer)? {
 						PlanOutcome::NeedReindex => {
 							next_reindex = true
 						},


### PR DESCRIPTION
This PR is implementing a simple fix for reindexing when the db is shut while reindexing (can see the effect by runing interupt.sh at https://github.com/cheme/parity-db/commit/ae6a19821b14a0921f67a8d4757912fe9712cfbb : basically the search existing index is broken and we amplify the index size by inserting multiple time the same index).

So this PR:
- adds reindexing by default at start.
- rebuild full key to reindex, this got an additional cost.

I guess a better fix would be to restore index from log, potentially allowing to avoid lookup of existing entry and avoid reindex all on restart, but having a check of full key without other assertion seems ok to me.