### PR TITLE
BE reindex

### DIFF
--- a/check_be.sh
+++ b/check_be.sh
@@ -1,0 +1,1 @@
+cargo +nightly miri test --release --target mips64-unknown-linux-gnuabi64 test_entries

--- a/check_be.sh
+++ b/check_be.sh
@@ -1,1 +1,0 @@
-cargo +nightly miri test --release --target mips64-unknown-linux-gnuabi64 test_entries

--- a/src/index.rs
+++ b/src/index.rs
@@ -24,8 +24,8 @@ use crate::{
 	stats::{self, ColumnStats},
 };
 
-const CHUNK_LEN: usize = 512; // bytes
-const CHUNK_ENTRIES: usize = 64;
+const CHUNK_LEN: usize = CHUNK_ENTRIES  * ENTRY_LEN as usize / 8; // 512 bytes
+const CHUNK_ENTRIES: usize = 1 << CHUNK_ENTRIES_BITS;
 const CHUNK_ENTRIES_BITS: u8 = 6;
 const HEADER_SIZE: usize = 512;
 const META_SIZE: usize = crate::table::SIZE_TIERS * 1024; // Contains header and column stats

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -19,11 +19,10 @@
 use std::sync::atomic::{AtomicU64, AtomicU32, Ordering};
 use std::mem::MaybeUninit;
 use std::io::{Read, Write, Cursor};
-use crate::{error::Result, column::ColId};
+use crate::{error::Result, column::ColId, table::SIZE_TIERS};
 
 const HISTOGRAM_BUCKETS: usize = 2048;
 const HISTOGRAM_BUCKET_BITS: u8 = 4;
-const SIZE_TIERS: usize = 16;
 
 pub const TOTAL_SIZE: usize = 4 * HISTOGRAM_BUCKETS + 8 * SIZE_TIERS + 8 * 10;
 
@@ -232,6 +231,3 @@ impl ColumnStats {
 		self.commits.fetch_add(1, Ordering::Relaxed);
 	}
 }
-
-
-

--- a/src/table.rs
+++ b/src/table.rs
@@ -67,6 +67,8 @@ use crate::{
 };
 
 pub const KEY_LEN: usize = 32;
+pub const SIZE_TIERS: usize = 16;
+pub const SIZE_TIERS_BITS: u8 = 4;
 const MAX_ENTRY_SIZE: usize = 65533;
 
 const TOMBSTONE: &[u8] = &[0xff, 0xff];


### PR DESCRIPTION
Quick fix for index transmute in be arch, and few utility function for index.

Removing the test and the .sh before merge could be a good idea (not that useful, except for implementing).