### PR TITLE
Burnt sushi says snap is as snappy as snappy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8.2"
 hex = "0.4.2"
 fs2 = "0.4.3"
 lz4 = "1.23.2"
-snappy = "0.4.0"
+snap = "1"
 
 [dev-dependencies]
 env_logger = "0.8.2"

--- a/src/column.rs
+++ b/src/column.rs
@@ -320,7 +320,7 @@ impl Column {
 					let (cur_size, compressed) = tables.value[existing_tier].size(&key, existing_address.offset(), log)?
 						.unwrap_or((0, false));
 					if compressed {
-						// This is very costy.
+						// This is very costly.
 						let compressed = tables.value[existing_tier].get(&key, existing_address.offset(), log)?
 							.expect("Same query as size").0;
 						let uncompressed = self.decompress(compressed.as_slice());
@@ -379,7 +379,7 @@ impl Column {
 					let (cur_size, compressed) = tables.value[existing_tier].size(&key, existing_address.offset(), log)?
 						.unwrap_or((0, false));
 					Some(if compressed {
-						// This is very costy.
+						// This is very costly.
 						let compressed = tables.value[existing_tier].get(&key, existing_address.offset(), log)?
 							.expect("Same query as size").0;
 						let uncompressed = self.decompress(compressed.as_slice());


### PR DESCRIPTION
Having everything pure rust just makes life simpler.

I ran the benchmark overriding it to do snappy compression by default and noted there were no ill effects, but I did note that the benchmark does not ever decompress anything at the moment so I've included a specific compression test.