### PR TITLE
Fix Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Key-value database for the blockchain"
 
 [dependencies]
 log = "0.4.8"
-parking_lot = "0.11	"
+parking_lot = "0.11"
 memmap2 = "0.2"
 blake2-rfc = "0.2.18"
 libc = "0.2"


### PR DESCRIPTION
The tab in the `parking-lot` dependency version seems to trip off some tools.