### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Please bump the version, as this problem [fixed here](https://github.com/paritytech/parity-db/commit/f349aa30e76f3219a90aaae99c0f3f07d994692e#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) was critical: 
Cargo will parse Cargo.toml and normalize **"   "** as **"/t"** = **"0.11/t"**,  thus tripping during the build.

Bumping the minor version allows all packages depending on "0.2.x" to build again.