### PR TITLE
Log cleanup queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ env_logger = "0.8.2"
 
 [profile.release]
 panic = "abort"
-codegen-units = 1
-lto = "fat"
+#codegen-units = 1
+#lto = "fat"
 debug = true
 
 [workspace]

--- a/bench/core/src/lib.rs
+++ b/bench/core/src/lib.rs
@@ -279,4 +279,3 @@ pub fn run<D: Db>() {
 		queries as f64  / elapsed
 	);
 }
-

--- a/src/column.rs
+++ b/src/column.rs
@@ -256,10 +256,9 @@ impl Column {
 	pub fn write_reindex_plan(&self, key: &Key, address: Address, log: &mut LogWriter) -> Result<PlanOutcome> {
 		let tables = self.tables.upgradable_read();
 		let reindex = self.reindex.upgradable_read();
-		/*
 		if Self::search_index(key, &tables.index, &*tables, log)?.is_some() {
 			return Ok(PlanOutcome::Skipped);
-		} */
+		}
 		match tables.index.write_insert_plan(key, address, None, log)? {
 			PlanOutcome::NeedReindex => {
 				log::debug!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));
@@ -519,7 +518,7 @@ impl Column {
 			if progress != source.id.total_chunks() {
 				let mut source_index = progress;
 				let mut count = 0;
-				if source_index % 50 == 0 {
+				if source_index % 500 == 0 {
 					log::debug!(target: "parity-db", "{}: Reindexing at {}/{}", tables.index.id, source_index, source.id.total_chunks());
 				}
 				log::debug!(target: "parity-db", "{}: Continue reindex at {}/{}", tables.index.id, source_index, source.id.total_chunks());

--- a/src/column.rs
+++ b/src/column.rs
@@ -256,10 +256,10 @@ impl Column {
 	pub fn write_reindex_plan(&self, key: &Key, address: Address, log: &mut LogWriter) -> Result<PlanOutcome> {
 		let tables = self.tables.upgradable_read();
 		let reindex = self.reindex.upgradable_read();
+		/*
 		if Self::search_index(key, &tables.index, &*tables, log)?.is_some() {
-			println!("SKIP REINDEX");
 			return Ok(PlanOutcome::Skipped);
-		}
+		} */
 		match tables.index.write_insert_plan(key, address, None, log)? {
 			PlanOutcome::NeedReindex => {
 				log::debug!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));

--- a/src/column.rs
+++ b/src/column.rs
@@ -257,6 +257,7 @@ impl Column {
 		let tables = self.tables.upgradable_read();
 		let reindex = self.reindex.upgradable_read();
 		if Self::search_index(key, &tables.index, &*tables, log)?.is_some() {
+			println!("SKIP REINDEX");
 			return Ok(PlanOutcome::Skipped);
 		}
 		match tables.index.write_insert_plan(key, address, None, log)? {

--- a/src/db.rs
+++ b/src/db.rs
@@ -646,7 +646,7 @@ impl DbInner {
 		self.log.flush_one(0)?;
 		while self.enact_logs(false)? {};
 		self.clean_all_logs()?;
-		self.log.kill_logs();
+		self.log.kill_logs()?;
 		if self.collect_stats {
 			let mut path = self.options.path.clone();
 			path.push("stats.txt");

--- a/src/db.rs
+++ b/src/db.rs
@@ -568,12 +568,11 @@ impl DbInner {
 
 	fn cleanup_logs(&self) -> Result<bool> {
 		let num_cleanup = self.log.num_dirty_logs();
-		/*
-		for c in self.columns.iter() {
-			c.flush()?;
-		}*/
-		if num_cleanup > 16 {
-			self.log.clean_logs(num_cleanup - 16)
+		if num_cleanup > 0 {
+			for c in self.columns.iter() {
+				c.flush()?;
+			}
+			self.log.clean_logs(num_cleanup)
 		} else {
 			Ok(false)
 		}

--- a/src/db.rs
+++ b/src/db.rs
@@ -468,7 +468,7 @@ impl DbInner {
 							}
 						};
 						match next {
-							LogAction::BeginRecord(_) => {
+							LogAction::BeginRecord => {
 								log::debug!(target: "parity-db", "Unexpected log header");
 								std::mem::drop(reader);
 								self.log.clear_replay_logs()?;
@@ -505,7 +505,7 @@ impl DbInner {
 				}
 				loop {
 					match reader.next()? {
-						LogAction::BeginRecord(_) => {
+						LogAction::BeginRecord => {
 							return Err(Error::Corruption("Bad log record".into()));
 						},
 						LogAction::EndRecord => {

--- a/src/db.rs
+++ b/src/db.rs
@@ -107,7 +107,7 @@ struct DbInner {
 	// Overlay of most recent values int the commit queue. ColumnId -> (Key -> (RecordId, Value)).
 	commit_overlay: RwLock<Vec<HashMap<Key, (u64, Option<Value>), IdentityBuildHasher>>>,
 	log_cv: Condvar,
-	log_queue_bytes: Mutex<i64>, // This may undeflow occasionally, but is bound for 0 eventually
+	log_queue_bytes: Mutex<i64>, // This may underflow occasionally, but is bound for 0 eventually
 	flush_worker_cv: Condvar,
 	flush_work: Mutex<bool>,
 	cleanup_worker_cv: Condvar,

--- a/src/db.rs
+++ b/src/db.rs
@@ -111,7 +111,6 @@ struct DbInner {
 	flush_work: Mutex<bool>,
 	cleanup_worker_cv: Condvar,
 	cleanup_work: Mutex<bool>,
-	enact_mutex: Mutex<()>,
 	last_enacted: AtomicU64,
 	next_reindex: AtomicU64,
 	collect_stats: bool,
@@ -155,7 +154,6 @@ impl DbInner {
 			flush_work: Mutex::new(false),
 			cleanup_worker_cv: Condvar::new(),
 			cleanup_work: Mutex::new(false),
-			enact_mutex: Mutex::new(()),
 			next_reindex: AtomicU64::new(1),
 			last_enacted: AtomicU64::new(1),
 			collect_stats: options.stats,
@@ -428,7 +426,6 @@ impl DbInner {
 
 	fn enact_logs(&self, validation_mode: bool) -> Result<bool> {
 		let cleared = {
-			//let _lock = self.enact_mutex.lock();
 			let reader = match self.log.read_next(validation_mode) {
 				Ok(reader) => reader,
 				Err(Error::Corruption(_)) if validation_mode => {

--- a/src/log.rs
+++ b/src/log.rs
@@ -441,6 +441,10 @@ impl Log {
 		path
 	}
 
+	pub fn replay_record_id(&self) -> Option<u64> {
+		self.replay_queue.read().front().map(|(_id, record_id, _)| *record_id)
+	}
+
 	pub fn open_log_file(path: &std::path::Path) -> Result<(std::fs::File, Option<u64>)> {
 		let mut file = std::fs::OpenOptions::new().read(true).write(true).open(path)?;
 		if file.metadata()?.len() == 0 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -681,6 +681,10 @@ impl Log {
 		}
 
 		let reading = self.reading.write();
+		if reading.is_none() {
+			log::trace!(target: "parity-db", "No active reader");
+			return Ok(None);
+		}
 		let reading = RwLockWriteGuard::map(reading, |r| &mut r.as_mut().unwrap().file);
 		let mut reader = LogReader::new(reading, validate);
 		match reader.next() {

--- a/src/log.rs
+++ b/src/log.rs
@@ -339,7 +339,7 @@ impl<'a> LogQuery for LogWriter<'a> {
 
 #[derive(Default)]
 pub struct IndexLogOverlay {
-	pub map: HashMap<u64, (u64, u64, IndexChunk)>, // index -> (record_id, mask, entry)
+	pub map: HashMap<u64, (u64, u64, IndexChunk)>, // index -> (record_id, modified_mask, entry)
 }
 
 
@@ -683,7 +683,7 @@ impl Log {
 		// Move cleaned logs back to the pool
 		let mut pool = self.log_pool.write();
 		pool.extend(cleaned);
-		// Sort to resue lower IDs an prevent IDs from growing.
+		// Sort to reuse lower IDs an prevent IDs from growing.
 		pool.make_contiguous().sort_by_key(|(id, _)| *id);
 		if pool.len() > MAX_LOG_POOL_SIZE {
 			let removed = pool.drain(MAX_LOG_POOL_SIZE..);

--- a/src/log.rs
+++ b/src/log.rs
@@ -738,19 +738,16 @@ impl Log {
 		&self.overlays
 	}
 
-	pub fn kill_logs(&self) {
+	pub fn kill_logs(&self) -> Result<()> {
 		let mut log_pool = self.log_pool.write();
 		for (id, file) in log_pool.drain(..) {
 			std::mem::drop(file);
-			if let Err(e) = self.drop_log(id) {
-				log::warn!(target: "parity-db", "Error removing log file {:?}", e);
-			}
+			self.drop_log(id)?;
 		}
 		if let Some(reading) = self.reading.write().take() {
 			std::mem::drop(reading.file);
-			if let Err(e) = self.drop_log(reading.id) {
-				log::warn!(target: "parity-db", "Error removing log file {:?}", e);
-			}
+			self.drop_log(reading.id)?;
 		}
+		Ok(())
 	}
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -710,5 +710,11 @@ impl Log {
 				log::warn!(target: "parity-db", "Error removing log file {:?}", e);
 			}
 		}
+		if let Some(reading) = self.reading.write().take() {
+			std::mem::drop(reading.file);
+			if let Err(e) = self.drop_log(reading.id) {
+				log::warn!(target: "parity-db", "Error removing log file {:?}", e);
+			}
+		}
 	}
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -30,8 +30,11 @@ pub struct Options {
 	/// Column settings
 	pub columns: Vec<ColumnOptions>,
 	/// fsync WAL to disk before commiting any changes. Provides extra consistency
-	/// guarantees. Off by default.
-	pub sync: bool,
+	/// guarantees. On by default.
+	pub sync_wal: bool,
+	/// fsync/msync data to disk before removing logs. Provides crash resistance guarantee.
+	/// On by default.
+	pub sync_data: bool,
 	/// Collect database statistics. May have effect on performance.
 	pub stats: bool,
 }
@@ -91,7 +94,8 @@ impl Options {
 	pub fn with_columns(path: &std::path::Path, num_columns: u8) -> Options {
 		Options {
 			path: path.into(),
-			sync: true,
+			sync_wal: true,
+			sync_data: true,
 			stats: true,
 			columns: (0..num_columns).map(|_| Default::default()).collect(),
 		}

--- a/src/table.rs
+++ b/src/table.rs
@@ -728,9 +728,9 @@ mod test {
 		let bytes_written = log.end_record(writer.drain()).unwrap();
 		// Cycle through 2 log files
 		let _ = log.read_next(false);
-		log.flush_one(0, || Ok(())).unwrap();
+		log.flush_one(0).unwrap();
 		let _ = log.read_next(false);
-		log.flush_one(0, || Ok(())).unwrap();
+		log.flush_one(0).unwrap();
 		let mut reader = log.read_next(false).unwrap().unwrap();
 		loop {
 			match reader.next().unwrap() {


### PR DESCRIPTION
Currently when we finish enacting WAL, we fsync/msync all data and delete the log file. Syncing data is expensive and may become a bottleneck under a heave write workload. We also can't keep writing to a next log while syncing data for previous log is in progress as the changes are kept in memory and this may lead to memory starvation.

This PR introduces WAL cleanup queue. Once log  file is fully read it is added to the cleanup queue. An additional thread syncs data and removes checkpointed logs from the queue. The tradeoff here is that if the sync is slow, log files may start accumulating wasting disk space. I consider this acceptable because eventually they will be deleted after the sync is complete.

Another change is that log records for index pages now only contain changes entries, and not the whole page.