### PR TITLE
Remove REF from value table when unneeded.

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -115,7 +115,7 @@ impl Column {
 	fn compress_internal(compression: &Compress, key: &Key, value: &[u8], tables: &Tables) -> (Option<Vec<u8>>, usize) {
 		let (len, result) = if value.len() > compression.treshold as usize {
 			let cvalue = compression.compress(value);
-			if cvalue.len() <= value.len() {
+			if cvalue.len() < value.len() {
 				(cvalue.len(), Some(cvalue))
 			} else {
 				(value.len(), None)

--- a/src/column.rs
+++ b/src/column.rs
@@ -23,7 +23,7 @@ use crate::{
 	log::{Log, LogOverlays, LogReader, LogWriter, LogAction},
 	display::hex,
 	index::{IndexTable, TableId as IndexTableId, PlanOutcome, Address},
-	options::Options,
+	options::{Options, ColumnOptions},
 	stats::ColumnStats,
 };
 use crate::compress::Compress;
@@ -147,22 +147,22 @@ impl Column {
 		let tables = Tables {
 			index,
 			value: [
-				Self::open_table(path, col, 0, Some(options.sizes[0]))?,
-				Self::open_table(path, col, 1, Some(options.sizes[1]))?,
-				Self::open_table(path, col, 2, Some(options.sizes[2]))?,
-				Self::open_table(path, col, 3, Some(options.sizes[3]))?,
-				Self::open_table(path, col, 4, Some(options.sizes[4]))?,
-				Self::open_table(path, col, 5, Some(options.sizes[5]))?,
-				Self::open_table(path, col, 6, Some(options.sizes[6]))?,
-				Self::open_table(path, col, 7, Some(options.sizes[7]))?,
-				Self::open_table(path, col, 8, Some(options.sizes[8]))?,
-				Self::open_table(path, col, 9, Some(options.sizes[9]))?,
-				Self::open_table(path, col, 10, Some(options.sizes[10]))?,
-				Self::open_table(path, col, 11, Some(options.sizes[11]))?,
-				Self::open_table(path, col, 12, Some(options.sizes[12]))?,
-				Self::open_table(path, col, 13, Some(options.sizes[13]))?,
-				Self::open_table(path, col, 14, Some(options.sizes[14]))?,
-				Self::open_table(path, col, 15, None)?,
+				Self::open_table(path, col, 0, &options)?,
+				Self::open_table(path, col, 1, &options)?,
+				Self::open_table(path, col, 2, &options)?,
+				Self::open_table(path, col, 3, &options)?,
+				Self::open_table(path, col, 4, &options)?,
+				Self::open_table(path, col, 5, &options)?,
+				Self::open_table(path, col, 6, &options)?,
+				Self::open_table(path, col, 7, &options)?,
+				Self::open_table(path, col, 8, &options)?,
+				Self::open_table(path, col, 9, &options)?,
+				Self::open_table(path, col, 10, &options)?,
+				Self::open_table(path, col, 11, &options)?,
+				Self::open_table(path, col, 12, &options)?,
+				Self::open_table(path, col, 13, &options)?,
+				Self::open_table(path, col, 14, &options)?,
+				Self::open_table(path, col, 15, &options)?,
 			],
 		};
 
@@ -226,9 +226,15 @@ impl Column {
 		Ok((table, reindexing, stats))
 	}
 
-	fn open_table(path: &std::path::Path, col: ColId, tier: u8, entry_size: Option<u16>) -> Result<ValueTable> {
+	fn open_table(
+		path: &std::path::Path,
+		col: ColId,
+		tier: u8,
+		options: &ColumnOptions,
+	) -> Result<ValueTable> {
 		let id = ValueTableId::new(col, tier);
-		ValueTable::open(path, id, entry_size)
+		let entry_size = options.sizes.get(tier as usize).cloned();
+		ValueTable::open(path, id, entry_size, options)
 	}
 
 	fn trigger_reindex(

--- a/src/db.rs
+++ b/src/db.rs
@@ -685,6 +685,8 @@ pub struct Db {
 impl Db {
 	pub fn with_columns(path: &std::path::Path, num_columns: u8) -> Result<Db> {
 		let options = Options::with_columns(path, num_columns);
+
+		assert!(options.is_valid());
 		Self::open(&options)
 	}
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -17,6 +17,7 @@
 use std::io::Write;
 use crate::error::{Error, Result};
 use crate::column::Salt;
+use crate::compress::CompressionType;
 use rand::Rng;
 
 const CURRENT_VERSION: u32 = 3;
@@ -51,10 +52,10 @@ pub struct ColumnOptions {
 	pub uniform: bool,
 	/// Value size tiers.
 	pub sizes: [u16; 15],
-	/// Use referece counting for values.
+	/// Use reference counting for values.
 	pub ref_counted: bool,
 	/// Compression to use for this column.
-	pub compression: crate::compress::CompressionType,
+	pub compression: CompressionType,
 	/// Minimal value size treshold to attempt compressing a value.
 	pub compression_treshold: u32,
 }
@@ -83,7 +84,7 @@ impl Default for ColumnOptions {
 			preimage: false,
 			uniform: false,
 			ref_counted: false,
-			compression: crate::compress::CompressionType::NoCompression,
+			compression: CompressionType::NoCompression,
 			compression_treshold: 4096,
 			sizes: [96, 128, 192, 256, 320, 512, 768, 1024, 1536, 2048, 3072, 4096, 8192, 16384, 32768],
 		}

--- a/src/options.rs
+++ b/src/options.rs
@@ -76,6 +76,15 @@ impl ColumnOptions {
 			})
 		)
 	}
+
+	pub fn is_valid(&self) -> bool {
+		for size in self.sizes {
+			if size >= crate::table::COMPRESSED_MASK {
+				return false;
+			}
+		}
+		true
+	}
 }
 
 impl Default for ColumnOptions {
@@ -86,7 +95,7 @@ impl Default for ColumnOptions {
 			ref_counted: false,
 			compression: CompressionType::NoCompression,
 			compression_treshold: 4096,
-			sizes: [96, 128, 192, 256, 320, 512, 768, 1024, 1536, 2048, 3072, 4096, 8192, 16384, 32768],
+			sizes: [96, 128, 192, 256, 320, 512, 768, 1024, 1536, 2048, 3072, 4096, 8192, 16384, 32760],
 		}
 	}
 }
@@ -155,5 +164,14 @@ impl Options {
 			}
 		}
 		Ok(salt)
+	}
+
+	pub fn is_valid(&self) -> bool {
+		for option in self.columns.iter() {
+			if !option.is_valid() {
+				return false;
+			}
+		}
+		true
 	}
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -75,7 +75,7 @@ use crate::{
 pub const KEY_LEN: usize = 32;
 pub const SIZE_TIERS: usize = 16;
 pub const SIZE_TIERS_BITS: u8 = 4;
-pub const COMPRESSED_MASK: u16 = 0xa0_00;
+pub const COMPRESSED_MASK: u16 = 0x80_00;
 const MAX_ENTRY_SIZE: usize = 0xfffd;
 const REFS_SIZE: usize = 4;
 const SIZE_SIZE: usize = 2;


### PR DESCRIPTION
This PR remove Rc from value when not needed.
When rc is not use, but compression is possible (active in option and on a table above compression threshold), then a bit is added to indicate if compression is used.
Also rc uses full 32 byte when no compression is possible.