### PR TITLE
prevent Db::open from creating new database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 .cargo/
 *.log
 test_db/
+
+# vim
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ snap = "1"
 
 [dev-dependencies]
 env_logger = "0.8.2"
+tempfile = "3.2"
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/db.rs
+++ b/src/db.rs
@@ -133,10 +133,10 @@ impl DbInner {
 		};
 		let mut lock_path: std::path::PathBuf = options.path.clone();
 		lock_path.push("lock");
-		let lock_file = std::fs::OpenOptions::new().create(create).read(true).write(true).open(lock_path.as_path())?;
+		let lock_file = std::fs::OpenOptions::new().create(true).read(true).write(true).open(lock_path.as_path())?;
 		lock_file.try_lock_exclusive().map_err(|e| Error::Locked(e))?;
 
-		let metadata = options.load_and_validate_metadata()?;
+		let metadata = options.load_and_validate_metadata(create)?;
 		let mut columns = Vec::with_capacity(metadata.columns.len());
 		let mut commit_overlay = Vec::with_capacity(metadata.columns.len());
 		let log = Log::open(&options)?;
@@ -964,6 +964,7 @@ mod tests {
 			Db::open(&options).is_err(),
 			"Database does not exist, so it should fail to open"
 		);
+		assert!(Db::open(&options).map(|_| ()).unwrap_err().to_string().contains("use open_or_create"));
 	}
 
 	#[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -183,7 +183,7 @@ impl Options {
 		Ok(())
 	}
 
-	pub fn load_and_validate_metadata(&self) -> Result<Metadata> {
+	pub fn load_and_validate_metadata(&self, create: bool) -> Result<Metadata> {
 		let mut path: PathBuf = self.path.clone();
 		path.push("metadata");
 		let meta = Self::load_metadata(&path)?;
@@ -201,7 +201,7 @@ impl Options {
 				}
 			}
 			Ok(meta)
-		} else {
+		} else if create {
 			let s: Salt = self.salt.unwrap_or(rand::thread_rng().gen());
 			self.write_metadata(&path, &s)?;
 			Ok(Metadata {
@@ -209,6 +209,8 @@ impl Options {
 				columns: self.columns.clone(),
 				salt: Some(s),
 			})
+		} else {
+			Err(Error::InvalidConfiguration("Database does not exist. To create a new one, use open_or_create".into()))
 		}
 	}
 


### PR DESCRIPTION
Currently `Db::open` creates new database, even tho it shouldn't. This PR fixes this behaviour and adds 2 simple tests