### PR TITLE
fix: madvise_random on not(unix)

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -499,7 +499,7 @@ impl IndexTable {
 
 	#[cfg(not(unix))]
 	fn madvise_random(&self, _map: &mut memmap2::MmapMut) {
-		Ok(())
+		()
 	}
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -498,9 +498,7 @@ impl IndexTable {
 	}
 
 	#[cfg(not(unix))]
-	fn madvise_random(&self, _map: &mut memmap2::MmapMut) {
-		()
-	}
+	fn madvise_random(&self, _map: &mut memmap2::MmapMut) {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
should return () instead of Result<()>