### PR TITLE
make parity-db build on windows

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -498,9 +498,7 @@ impl IndexTable {
 	}
 
 	#[cfg(not(unix))]
-	fn madvise_random(&self, _map: &mut memmap2::MmapMut) {
-		Ok(())
-	}
+	fn madvise_random(&self, _map: &mut memmap2::MmapMut) {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
No need to return a `Result`

![image](https://user-images.githubusercontent.com/4054836/133364975-e72e948a-1354-49b2-b0cb-7b57cdbd73a5.png)
