### PR TITLE
Fix potential corruption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -45,7 +45,7 @@ pub fn run() -> Result<(), String> {
 		.map_err(|e| format!("Error resolving metas: {:?}", e))? {
 		let mut options = parity_db::Options::with_columns(db_path.as_path(), 0);
 		options.columns = metadata.columns;
-		options.salt = metadata.salt;
+		options.salt = Some(metadata.salt);
 		options
 	} else {
 		parity_db::Options::with_columns(db_path.as_path(), nb_column)

--- a/src/column.rs
+++ b/src/column.rs
@@ -597,7 +597,7 @@ impl Column {
 					},
 				};
 				let mut key = source.recover_key_prefix(c, *entry);
-				&mut key[6..].copy_from_slice(&pk);
+				key[6..].copy_from_slice(&pk);
 				let value = if compressed {
 						self.decompress(&value)
 				} else {

--- a/src/column.rs
+++ b/src/column.rs
@@ -53,7 +53,7 @@ pub struct Column {
 	uniform_keys: bool,
 	collect_stats: bool,
 	ref_counted: bool,
-	salt: Option<Salt>,
+	salt: Salt,
 	stats: ColumnStats,
 	compression: Compress,
 	db_version: u32,
@@ -188,10 +188,8 @@ impl Column {
 		let mut k = Key::default();
 		if self.uniform_keys {
 			k.copy_from_slice(&key[0..32]);
-		} else if let Some(salt) = &self.salt {
-			k.copy_from_slice(blake2_rfc::blake2b::blake2b(32, &salt[..], &key).as_bytes());
 		} else {
-			k.copy_from_slice(blake2_rfc::blake2b::blake2b(32, &[], &key).as_bytes());
+			k.copy_from_slice(blake2_rfc::blake2b::blake2b(32, &self.salt, &key).as_bytes());
 		}
 		k
 	}

--- a/src/index.rs
+++ b/src/index.rs
@@ -268,7 +268,7 @@ impl IndexTable {
 		let index_key = (chunk << 64 - self.id.index_bits()) |
 			(partial_key << (64 - k - self.id.index_bits()));
 		let mut key = Key::default();
-		&mut key[0..8].copy_from_slice(&index_key.to_be_bytes());
+		key[0..8].copy_from_slice(&index_key.to_be_bytes());
 		key
 	}
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -37,14 +37,14 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &Ve
 	}
 
 	// Make sure we are using the same salt value.
-	to.salt = source_meta.salt;
+	to.salt = Some(source_meta.salt);
 
 	if (to.salt.is_none()) && overwrite {
 		return Err(Error::Migration("Changing salt need to update metadata at once.".into()));
 	}
 
 	let mut source_options = Options::with_columns(from, source_meta.columns.len() as u8);
-	source_options.salt = source_meta.salt;
+	source_options.salt = Some(source_meta.salt);
 	source_options.columns = source_meta.columns;
 	
 	let mut source = Db::open(&source_options)?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -70,8 +70,8 @@ pub struct ColumnOptions {
 /// Database metadata.
 #[derive(Clone, Debug)]
 pub struct Metadata {
-	/// Salt value. `None` only for version <= 3.
-	pub salt: Option<Salt>,
+	/// Salt value.
+	pub salt: Salt,
 	/// Database version.
 	pub version: u32,
 	/// Column metadata.
@@ -207,7 +207,7 @@ impl Options {
 			Ok(Metadata {
 				version: CURRENT_VERSION,
 				columns: self.columns.clone(),
-				salt: Some(s),
+				salt: s,
 			})
 		} else {
 			Err(Error::InvalidConfiguration("Database does not exist. To create a new one, use open_or_create".into()))
@@ -246,12 +246,7 @@ impl Options {
 			return Err(Error::InvalidConfiguration(format!(
 						"Unsupported database version {}. Expected {}", version, CURRENT_VERSION)));
 		}
-		if version == 3 {
-			//Treat all tables as ref counted.
-			for mut col in &mut columns {
-				col.ref_counted = true;
-			}
-		}
+		let salt = salt.ok_or_else(|| Error::InvalidConfiguration("Missing salt value".into()))?;
 		Ok(Some(Metadata {
 			version,
 			columns,
@@ -271,12 +266,6 @@ impl Options {
 
 impl Metadata {
 	pub fn columns_to_migrate(&self) -> std::collections::BTreeSet<u8> {
-		let mut result = std::collections::BTreeSet::new();
-		if self.version == 3 {
-			for i in 0 .. self.columns.len() as u8 {
-				result.insert(i);
-			}
-		}
-		result
+		std::collections::BTreeSet::new()
 	}
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -22,9 +22,9 @@ use crate::column::Salt;
 use crate::compress::CompressionType;
 use rand::Rng;
 
-pub const CURRENT_VERSION: u32 = 4;
-// TODO on last supported 4, remove `ValueTable` `no_compression` field.
-const LAST_SUPPORTED_VERSION: u32 = 3;
+pub const CURRENT_VERSION: u32 = 5;
+// TODO on last supported 5, remove MULTIHEAD_V4 and MULTIPART_V4
+const LAST_SUPPORTED_VERSION: u32 = 4;
 
 /// Database configuration.
 #[derive(Clone, Debug)]

--- a/src/table.rs
+++ b/src/table.rs
@@ -123,10 +123,6 @@ impl TableId {
 		format!("table_{:02}_{}", self.col(), hex(&[self.size_tier()]))
 	}
 
-	pub fn legacy_file_name(&self) -> String {
-		format!("table_{:02}_{}", self.col(), self.size_tier())
-	}
-
 	pub fn is_file_name(col: ColId, name: &str) -> bool {
 		name.starts_with(&format!("table_{:02}_", col))
 	}
@@ -363,13 +359,8 @@ impl ValueTable {
 		}
 
 		let mut filepath: std::path::PathBuf = std::path::PathBuf::clone(&*path);
-		// Check for old file name format
-		filepath.push(id.legacy_file_name());
-		let mut file = if db_version == 3 && std::fs::metadata(&filepath).is_ok() {
-			Some(std::fs::OpenOptions::new().create(true).read(true).write(true).open(filepath.as_path())?)
-		} else {
-			filepath.pop();
-			filepath.push(id.file_name());
+		filepath.push(id.file_name());
+		let mut file = {
 			if std::fs::metadata(&filepath).is_ok() {
 				Some(std::fs::OpenOptions::new().create(true).read(true).write(true).open(filepath.as_path())?)
 			} else {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1286,5 +1286,14 @@ mod test {
 			table.write_dec_ref(1, writer).unwrap();
 		});
 		assert_eq!(table.last_removed.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+		// Check that max entry size values are OK.
+		let value_size = table.value_size();
+		assert_eq!(0x7fd8, table.value_size()); // Max value size for this configuration.
+		let val = value(value_size as usize); // This result in 0x7ff8 entry size.
+		write_ops(&table, &log, |writer| {
+			table.write_insert_plan(&key, &val, writer, compressed).unwrap();
+		});
+		assert_eq!(table.get(&key, 1, log.overlays()).unwrap(), Some((val.clone(), compressed)));
 	}
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -75,7 +75,7 @@ pub const KEY_LEN: usize = 32;
 pub const SIZE_TIERS: usize = 1usize << SIZE_TIERS_BITS;
 pub const SIZE_TIERS_BITS: u8 = 8;
 pub const COMPRESSED_MASK: u16 = 0x80_00;
-pub const MAX_ENTRY_SIZE: usize = 0x7ff8;
+pub const MAX_ENTRY_SIZE: usize = 0x7ff8; // Actual max size in V4 was 0x7dfe
 pub const MIN_ENTRY_SIZE: usize = 32;
 const REFS_SIZE: usize = 4;
 const SIZE_SIZE: usize = 2;
@@ -84,8 +84,10 @@ const INDEX_SIZE: usize = 8;
 const MAX_ENTRY_BUF_SIZE: usize = 0x8000;
 
 const TOMBSTONE: &[u8] = &[0xff, 0xff];
-const MULTIPART: &[u8] = &[0xff, 0xfe];
-const MULTIHEAD: &[u8] = &[0xff, 0xfd];
+const MULTIPART_V4: &[u8] = &[0xff, 0xfe];
+const MULTIHEAD_V4: &[u8] = &[0xff, 0xfd];
+const MULTIPART: &[u8] = &[0xfe, 0xff];
+const MULTIHEAD: &[u8] = &[0xfd, 0xff];
 // When a rc reach locked ref, it is locked in db.
 const LOCKED_REF: u32 = u32::MAX;
 
@@ -152,7 +154,7 @@ pub struct ValueTable {
 	dirty: AtomicBool,
 	multipart: bool,
 	ref_counted: bool,
-	no_compression: bool, // This legacy table can't be compressed. TODO: remove this
+	db_version: u32,
 }
 
 #[cfg(target_os = "linux")]
@@ -223,6 +225,7 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Entry<B> {
 		self.0 += buf.len();
 		self.1.as_mut()[start..self.0].copy_from_slice(buf);
 	}
+
 	fn read_slice(&mut self, size: usize) -> &[u8] {
 		let start = self.0;
 		self.0 += size;
@@ -232,6 +235,7 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Entry<B> {
 	fn is_tombstone(&self) -> bool {
 		&self.1.as_ref()[0..SIZE_SIZE] == TOMBSTONE
 	}
+
 	fn write_tombstone(&mut self) {
 		self.write_slice(&TOMBSTONE);
 	}
@@ -239,28 +243,42 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Entry<B> {
 	fn is_multipart(&self) -> bool {
 		&self.1.as_ref()[0..SIZE_SIZE] == MULTIPART
 	}
+
+	fn is_multipart_v4(&self) -> bool {
+		&self.1.as_ref()[0..SIZE_SIZE] == MULTIPART_V4
+	}
+
 	fn write_multipart(&mut self) {
 		self.write_slice(&MULTIPART);
 	}
+
 	fn is_multihead(&self) -> bool {
 		&self.1.as_ref()[0..SIZE_SIZE] == MULTIHEAD
 	}
+
+	fn is_multihead_v4(&self) -> bool {
+		&self.1.as_ref()[0..SIZE_SIZE] == MULTIHEAD_V4
+	}
+
 	fn write_multihead(&mut self) {
 		self.write_slice(&MULTIHEAD);
 	}
 
-	fn read_size(&mut self, no_compression: bool) -> (u16, bool) {
-		let size = u16::from_le_bytes(self.read_slice(SIZE_SIZE).try_into().unwrap());
-		if !no_compression {
-			let compressed = (size & COMPRESSED_MASK) > 0;
-			(size & !COMPRESSED_MASK, compressed)
-		} else {
-			(size, false)
-		}
+	fn is_multi(&self, db_version: u32) -> bool {
+		self.is_multipart() || self.is_multihead() ||
+			(db_version <= 4 && (self.is_multipart_v4() || self.is_multihead_v4()))
 	}
+
+	fn read_size(&mut self) -> (u16, bool) {
+		let size = u16::from_le_bytes(self.read_slice(SIZE_SIZE).try_into().unwrap());
+		let compressed = (size & COMPRESSED_MASK) > 0;
+		(size & !COMPRESSED_MASK, compressed)
+	}
+
 	fn skip_size(&mut self) {
 		self.0 += SIZE_SIZE;
 	}
+
 	fn write_size(&mut self, mut size: u16, compressed: bool) {
 		if compressed {
 			size |= COMPRESSED_MASK;
@@ -271,9 +289,11 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Entry<B> {
 	fn read_next(&mut self) -> u64 {
 		u64::from_le_bytes(self.read_slice(INDEX_SIZE).try_into().unwrap())
 	}
+
 	fn skip_next(&mut self) {
 		self.0 += INDEX_SIZE;
 	}
+
 	fn write_next(&mut self, next_index: u64) {
 		self.write_slice(&next_index.to_le_bytes());
 	}
@@ -281,9 +301,11 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Entry<B> {
 	fn read_rc(&mut self) -> u32 {
 		u32::from_le_bytes(self.read_slice(REFS_SIZE).try_into().unwrap())
 	}
+
 	fn skip_rc(&mut self) {
 		self.0 += REFS_SIZE;
 	}
+
 	fn write_rc(&mut self, rc: u32) {
 		self.write_slice(&rc.to_le_bytes());
 	}
@@ -389,7 +411,7 @@ impl ValueTable {
 			dirty: AtomicBool::new(false),
 			multipart,
 			ref_counted: options.ref_counted,
-			no_compression: db_version <= 3,
+			db_version,
 		})
 	}
 
@@ -495,12 +517,12 @@ impl ValueTable {
 				return Ok((0, Default::default(), false));
 			}
 
-			let (entry_end, next) = if buf.is_multipart() || buf.is_multihead() {
+			let (entry_end, next) = if self.multipart && buf.is_multi(self.db_version) {
 				buf.skip_size();
 				let next = buf.read_next();
 				(entry_size, next)
 			} else {
-				let (size, read_compressed) = buf.read_size(self.no_compression);
+				let (size, read_compressed) = buf.read_size();
 				compressed = read_compressed;
 				(buf.offset() + size as usize, 0)
 			};
@@ -584,7 +606,7 @@ impl ValueTable {
 			return Ok(None);
 		}
 		buf.skip_size();
-		if buf.is_multipart() || buf.is_multihead() {
+		if self.multipart && buf.is_multi(self.db_version) {
 			buf.skip_next();
 		}
 		if self.ref_counted {
@@ -610,7 +632,7 @@ impl ValueTable {
 		if !log.value(self.id, index, buf.as_mut()) {
 			self.read_at(buf.as_mut(), index * self.entry_size as u64)?;
 		}
-		if buf.is_multipart() || buf.is_multihead() {
+		if self.multipart && buf.is_multi(self.db_version) {
 			buf.skip_size();
 			let next = buf.read_next();
 			return Ok(Some(next));
@@ -798,12 +820,12 @@ impl ValueTable {
 			return Ok(false);
 		}
 
-		let size = if buf.is_multipart() || buf.is_multihead() {
+		let size = if self.multipart && buf.is_multi(self.db_version) {
 			buf.skip_size();
 			buf.skip_next();
 			self.entry_size as usize
 		} else {
-			let (size, _compressed) = buf.read_size(self.no_compression);
+			let (size, _compressed) = buf.read_size();
 			buf.offset() + size as usize
 		};
 
@@ -848,13 +870,13 @@ impl ValueTable {
 			log.read(&mut buf[SIZE_SIZE..SIZE_SIZE + INDEX_SIZE])?;
 			self.write_at(&buf[0..SIZE_SIZE + INDEX_SIZE], index * (self.entry_size as u64))?;
 			log::trace!(target: "parity-db", "{}: Enacted tombstone in slot {}", self.id, index);
-		} else if buf.is_multipart() || buf.is_multihead() {
+		} else if self.multipart && buf.is_multi(self.db_version) {
 				let entry_size = self.entry_size as usize;
 				log.read(&mut buf[SIZE_SIZE..entry_size])?;
 				self.write_at(&buf[0..entry_size], index * (entry_size as u64))?;
 				log::trace!(target: "parity-db", "{}: Enacted multipart in slot {}", self.id, index);
 		} else {
-			let (len, _compressed) = buf.read_size(self.no_compression);
+			let (len, _compressed) = buf.read_size();
 			log.read(&mut buf[SIZE_SIZE..SIZE_SIZE + len as usize])?;
 			self.write_at(&buf[0..(SIZE_SIZE + len as usize)], index * (self.entry_size as u64))?;
 			log::trace!(target: "parity-db", "{}: Enacted {}: {}, {} bytes", self.id, index, hex(&buf.1[6..32]), len);
@@ -875,13 +897,13 @@ impl ValueTable {
 			log.read(&mut buf[SIZE_SIZE..SIZE_SIZE + INDEX_SIZE])?;
 			log::trace!(target: "parity-db", "{}: Validated tombstone in slot {}", self.id, index);
 		}
-		else if buf.is_multipart() || buf.is_multihead() {
+		else if self.multipart && buf.is_multi(self.db_version) {
 			let entry_size = self.entry_size as usize;
 			log.read(&mut buf[SIZE_SIZE..entry_size])?;
 			log::trace!(target: "parity-db", "{}: Validated multipart in slot {}", self.id, index);
 		} else {
 			// TODO: check len
-			let (len, _compressed) = buf.read_size(self.no_compression);
+			let (len, _compressed) = buf.read_size();
 			log.read(&mut buf[SIZE_SIZE..SIZE_SIZE + len as usize])?;
 			log::trace!(target: "parity-db", "{}: Validated {}: {}, {} bytes", self.id, index, hex(&buf[SIZE_SIZE..32]), len);
 		}


### PR DESCRIPTION
Since size is stored as 16-bit little endian in value tables, it could potentially result in a byte value that matches  `MULTIHEAD` and `MULTIPART`.  

* Changes  byte order in `MULTIHEAD` and `MULTIPART` values to avoid collisions.
* Disables multipart tracking for fixed size entry tables.
* Removed v3 compatibility