### PR TITLE
Fix iteration restart on commit.

### DIFF
--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -30,7 +30,6 @@ use crate::error::Result;
 use parking_lot::RwLock;
 use crate::btree::BTreeTable;
 
-
 pub struct BTreeIterator<'a> {
 	table: &'a BTreeTable,
 	log: &'a RwLock<crate::log::LogOverlays>,
@@ -244,7 +243,7 @@ impl BTreeIterState {
 
 	pub fn seek(&mut self, key: &[u8], btree: &mut BTree, col: &BTreeTable, log: &impl LogQuery, after: bool) -> Result<()> {
 		self.state.clear();
-		self.record_id = btree.record_id;
+		self.next_separator = false;
 		if col.with_locked(|b| {
 			let root = BTree::fetch_root(btree.root_index.unwrap_or(NULL_ADDRESS), b, log)?;
 			Node::seek(root, key, b, log, btree.depth, &mut self.state)

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -38,7 +38,7 @@ pub struct BTreeIterator<'a> {
 	iter: BtreeIterBackend,
 	col: ColId,
 	pending_next_backend: Option<Option<(Vec<u8>, Vec<u8>)>>,
-	overlay_last_key: Option<Vec<u8>>,
+	last_key: Option<Vec<u8>>,
 	from_seek: bool,
 }
 
@@ -59,7 +59,7 @@ impl<'a> BTreeIterator<'a> {
 			iter: BtreeIterBackend(tree, iter),
 			col,
 			pending_next_backend: None,
-			overlay_last_key: None,
+			last_key: None,
 			from_seek: false,
 			log,
 			commit_overlay,
@@ -72,9 +72,9 @@ impl<'a> BTreeIterator<'a> {
 		let log = self.log.read();
 		let record_id = log.last_record_id(self.col);
 		self.from_seek = !after;
-		self.overlay_last_key = Some(key.to_vec());
+		self.last_key = Some(key.to_vec());
 		self.pending_next_backend = None;
-		self.seek_backend(key.to_vec(), record_id, self.table, &*log, after)
+		self.seek_backend(key, record_id, self.table, &*log, after)
 	}
 
 	pub fn next(&mut self) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
@@ -84,9 +84,13 @@ impl<'a> BTreeIterator<'a> {
 		let log = self.log.read();
 		let record_id = log.last_record_id(self.col);
 		let commit_overlay = self.commit_overlay.read();
-		let next_commit_overlay = commit_overlay.get(col as usize).and_then(|o| o.btree_next(&self.overlay_last_key, self.from_seek));
+		let next_commit_overlay = commit_overlay.get(col as usize)
+			.and_then(|o| o.btree_next(&self.last_key, self.from_seek));
 		// No consistency over iteration, allows dropping lock to overlay.
 		std::mem::drop(commit_overlay);
+		if record_id != self.iter.1.record_id {
+			self.pending_next_backend = None;
+		}
 		let next_backend = if let Some(n) = self.pending_next_backend.take() {
 			n
 		} else {
@@ -98,12 +102,12 @@ impl<'a> BTreeIterator<'a> {
 				match commit_key.cmp(&backend_key) {
 					std::cmp::Ordering::Less => {
 						if let Some(value) = commit_value {
-							self.overlay_last_key = Some(commit_key.clone());
+							self.last_key = Some(commit_key.clone());
 							self.from_seek = false;
 							self.pending_next_backend = Some(Some((backend_key, backend_value)));
 							return Ok(Some((commit_key, value)));
 						} else {
-							self.overlay_last_key = Some(commit_key);
+							self.last_key = Some(commit_key);
 							self.from_seek = false;
 							self.pending_next_backend = Some(Some((backend_key, backend_value)));
 							std::mem::drop(log);
@@ -111,15 +115,16 @@ impl<'a> BTreeIterator<'a> {
 						}
 					},
 					std::cmp::Ordering::Greater => {
+						self.last_key = Some(backend_key.clone());
 						return Ok(Some((backend_key, backend_value)));
 					},
 					std::cmp::Ordering::Equal => {
 						if let Some(value) = commit_value {
-							self.overlay_last_key = Some(commit_key);
+							self.last_key = Some(commit_key);
 							self.from_seek = false;
 							return Ok(Some((backend_key, value)));
 						} else {
-							self.overlay_last_key = Some(commit_key);
+							self.last_key = Some(commit_key);
 							self.from_seek = false;
 							std::mem::drop(log);
 							return self.next();
@@ -129,12 +134,12 @@ impl<'a> BTreeIterator<'a> {
 			},
 			(Some((commit_key, commit_value)), None) => {
 				if let Some(value) = commit_value {
-					self.overlay_last_key = Some(commit_key.clone());
+					self.last_key = Some(commit_key.clone());
 					self.from_seek = false;
 					self.pending_next_backend = Some(None);
 					return Ok(Some((commit_key, value)));
 				} else {
-					self.overlay_last_key = Some(commit_key);
+					self.last_key = Some(commit_key);
 					self.from_seek = false;
 					self.pending_next_backend = Some(None);
 					std::mem::drop(log);
@@ -142,6 +147,7 @@ impl<'a> BTreeIterator<'a> {
 				}
 			},
 			(None, Some((backend_key, backend_value))) => {
+				self.last_key = Some(backend_key.clone());
 				return Ok(Some((backend_key, backend_value)));
 			},
 			(None, None) => {
@@ -156,15 +162,20 @@ impl<'a> BTreeIterator<'a> {
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, log, record_id))?;
 			*tree = new_tree;
+			if let Some(last_key) = self.last_key.as_ref() {
+				iter.seek(last_key.as_slice(), tree, col, log, true)?;
+			}
+			iter.record_id = record_id;
 		}
 		iter.next(tree, col, log)
 	}
 
-	pub fn seek_backend(&mut self, key: Vec<u8>, record_id: u64, col: &BTreeTable, log: &impl LogQuery, after: bool) -> Result<()> {
+	pub fn seek_backend(&mut self, key: &[u8], record_id: u64, col: &BTreeTable, log: &impl LogQuery, after: bool) -> Result<()> {
 		let BtreeIterBackend(tree, iter) = &mut self.iter;
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, log, record_id))?;
 			*tree = new_tree;
+			iter.record_id = record_id;
 		}
 		iter.seek(key, tree, col, log, after)
 	}
@@ -174,29 +185,25 @@ pub struct BTreeIterState {
 	state: Vec<(usize, Node)>,
 	next_separator: bool,
 	pub record_id: u64,
-	// After state change, we seek to this last accessed key.
-	pub last_key: Option<Vec<u8>>,
 }
 
 impl BTreeIterState {
 	pub fn new(record_id: u64) -> BTreeIterState {
 		BTreeIterState {
-			last_key: None,
 			next_separator: false,
 			state: vec![],
 			record_id,
 		}
 	}
 
-	pub fn next(&mut self, btree: &mut BTree, col: &BTreeTable, log: &impl LogQuery) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+	pub fn next(
+		&mut self,
+		btree: &mut BTree,
+		col: &BTreeTable,
+		log: &impl LogQuery,
+	) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
 		if self.next_separator && self.state.is_empty() {
 			return Ok(None);
-		}
-		if self.record_id != btree.record_id {
-			self.state.clear();
-			if let Some(last_key) = self.last_key.take() {
-				self.seek(last_key, btree, col, log, true)?;
-			}
 		}
 		if !self.next_separator {
 			if self.state.is_empty() {
@@ -226,7 +233,6 @@ impl BTreeIterState {
 
 					let key_query = TableKeyQuery::Fetch(None);
 					let r = col.get_at_value_index(key_query, address, log)?;
-					self.last_key = Some(key.clone());
 					return Ok(r.map(|r| (key, r.1)));
 				}
 			}
@@ -236,13 +242,12 @@ impl BTreeIterState {
 		self.next(btree, col, log)
 	}
 
-	pub fn seek(&mut self, key: Vec<u8>, btree: &mut BTree, col: &BTreeTable, log: &impl LogQuery, after: bool) -> Result<()> {
+	pub fn seek(&mut self, key: &[u8], btree: &mut BTree, col: &BTreeTable, log: &impl LogQuery, after: bool) -> Result<()> {
 		self.state.clear();
 		self.record_id = btree.record_id;
-		self.last_key = Some(key.to_vec());
 		if col.with_locked(|b| {
 			let root = BTree::fetch_root(btree.root_index.unwrap_or(NULL_ADDRESS), b, log)?;
-			Node::seek(root, key.as_ref(), b, log, btree.depth, &mut self.state)
+			Node::seek(root, key, b, log, btree.depth, &mut self.state)
 		})? {
 			// on value
 			if after {

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -426,13 +426,9 @@ impl Node {
 		Ok(())
 	}
 
-	pub fn need_rebalance(&mut self) -> bool {
-		let mut rebalance = false;
+	fn need_rebalance(&mut self) -> bool {
 		let middle = ORDER / 2;
-		if !self.has_separator(middle - 1) {
-			rebalance = true;
-		}
-		rebalance
+		!self.has_separator(middle - 1)
 	}
 
 	pub fn need_remove_root(

--- a/src/db.rs
+++ b/src/db.rs
@@ -1855,7 +1855,8 @@ mod tests {
 					state_next = iter_state.next();
 				}
 			}
-			assert_eq!(state_next, iter.next().unwrap().as_ref().map(|(k, v)| (k, v)));
+			let iter_next = iter.next().unwrap();
+			assert_eq!(state_next, iter_next.as_ref().map(|(k, v)| (k, v)));
 		}
 	}
 }


### PR DESCRIPTION
Iteration restart on commit was failing (I did not run the test enough, also found that tests sometime deadlock when using https://github.com/paritytech/parity-db/pull/47, but unrelated).
The commit overlay was a bit to much uncoupled from the backend resulting on inconsistencies.

This PR fix that. It also move the logic to restart iteration out of btree state iterator.