### PR TITLE
Fix a truckload of clippy annotations, warnings and errors.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+[*]
+indent_style=tab
+indent_size=tab
+tab_width=4
+end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+max_line_length=100
+insert_final_newline=true
+
+[*.md]
+max_line_length=80
+indent_style=space
+indent_size=2
+
+[*.yml]
+indent_style=space
+indent_size=2
+tab_width=8
+end_of_line=lf
+
+[*.sh]
+indent_style=space
+indent_size=2
+tab_width=8
+end_of_line=lf

--- a/admin/src/bench/db.rs
+++ b/admin/src/bench/db.rs
@@ -22,5 +22,5 @@ pub trait Db: Send + Sync + 'static {
 	fn open(path: &std::path::Path) -> Self;
 	fn with_options(options: &Self::Options) -> Self;
 	fn get(&self, key: &Key) -> Option<Value>;
-	fn commit<I: IntoIterator<Item=(Key, Option<Value>)>>(&self, tx: I);
+	fn commit<I: IntoIterator<Item = (Key, Option<Value>)>>(&self, tx: I);
 }

--- a/admin/src/bench/mod.rs
+++ b/admin/src/bench/mod.rs
@@ -14,19 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-/// Stress subcommand.
-
-use structopt::StructOpt;
 use super::*;
+/// Stress subcommand.
+use structopt::StructOpt;
 
 mod db;
 mod sizes;
 
-pub use parity_db::{Key, Value, Db, CompressionType};
 pub use db::Db as BenchDb;
+pub use parity_db::{CompressionType, Db, Key, Value};
 
-use std::{sync::{atomic::{AtomicBool, AtomicUsize, Ordering}, Arc, }, thread};
-use rand::{SeedableRng, RngCore};
+use rand::{RngCore, SeedableRng};
+use std::{
+	sync::{
+		atomic::{AtomicBool, AtomicUsize, Ordering},
+		Arc,
+	},
+	thread,
+};
 
 static COMMITS: AtomicUsize = AtomicUsize::new(0);
 //static QUERIES: AtomicUsize = AtomicUsize::new(0);
@@ -63,7 +68,7 @@ impl BenchDb for BenchAdapter {
 		self.0.get(0, key).unwrap()
 	}
 
-	fn commit<I: IntoIterator<Item=(Key, Option<Value>)>>(&self, tx: I) {
+	fn commit<I: IntoIterator<Item = (Key, Option<Value>)>>(&self, tx: I) {
 		self.0.commit(tx.into_iter().map(|(k, v)| (0, k, v))).unwrap()
 	}
 }
@@ -159,15 +164,13 @@ impl SizePool {
 	fn value(&self, seed: u64, compressable: bool) -> Vec<u8> {
 		let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
 		let sr = (rng.next_u64() % self.total as u64) as u32;
-		let mut range = self.distribution.range((std::ops::Bound::Included(sr), std::ops::Bound::Unbounded));
+		let mut range = self
+			.distribution
+			.range((std::ops::Bound::Included(sr), std::ops::Bound::Unbounded));
 		let size = *range.next().unwrap().1 as usize;
 		let mut v = Vec::new();
 		v.resize(size, 0);
-		let fill = if !compressable {
-			size
-		} else {
-			size / 2
-		};
+		let fill = if !compressable { size } else { size / 2 };
 		rng.fill_bytes(&mut v[..fill]);
 		v
 	}
@@ -187,28 +190,41 @@ fn informant(shutdown: Arc<AtomicBool>, total: usize, start: usize) {
 		thread::sleep(std::time::Duration::from_secs(1));
 		let commits = COMMITS.load(Ordering::Acquire);
 		let now = std::time::Instant::now();
-		println!("{}/{} commits, {} cps", commits - start, total,  ((commits - last) as f64) / (now - last_time).as_secs_f64());
+		println!(
+			"{}/{} commits, {} cps",
+			commits - start,
+			total,
+			((commits - last) as f64) / (now - last_time).as_secs_f64()
+		);
 		last = commits;
 		last_time = now;
 	}
 }
 
-fn writer<D: BenchDb>(db: Arc<D>, args: Arc<Args>, pool: Arc<SizePool>, shutdown: Arc<AtomicBool>, start_commit: usize) {
+fn writer<D: BenchDb>(
+	db: Arc<D>,
+	args: Arc<Args>,
+	pool: Arc<SizePool>,
+	shutdown: Arc<AtomicBool>,
+	start_commit: usize,
+) {
 	let offset = args.seed.unwrap_or(0);
 	// Note that multiple worker will run on same range concurrently.
 	let mut key = start_commit as u64 * COMMIT_SIZE as u64 + offset;
 	let commit_size = COMMIT_SIZE;
 	let mut commit = Vec::with_capacity(commit_size);
 
-	for n in start_commit .. start_commit + args.commits {
-		if shutdown.load(Ordering::Relaxed) { break; }
-		for _ in 0 .. commit_size {
+	for n in start_commit..start_commit + args.commits {
+		if shutdown.load(Ordering::Relaxed) {
+			break
+		}
+		for _ in 0..commit_size {
 			commit.push((pool.key(key), Some(pool.value(key, args.compress))));
 			key += 1;
 		}
 		if !args.archive && n >= COMMIT_PRUNE_WINDOW {
 			let prune_start = (n - COMMIT_PRUNE_WINDOW) * COMMIT_SIZE + offset as usize;
-			for p in prune_start .. prune_start + COMMIT_PRUNE_SIZE {
+			for p in prune_start..prune_start + COMMIT_PRUNE_SIZE {
 				commit.push((pool.key(p as u64), None));
 			}
 		}
@@ -254,19 +270,19 @@ pub fn run_internal<D: BenchDb>(args: Args, db: D) {
 		threads.push(thread::spawn(move || informant(shutdown, commits, start)));
 	}
 
-	for i in 0 .. args.readers {
+	for i in 0..args.readers {
 		let db = db.clone();
 		let shutdown = shutdown.clone();
 
 		threads.push(
 			thread::Builder::new()
-			.name(format!("reader {}", i))
-			.spawn(move || reader(db, shutdown))
-			.unwrap()
+				.name(format!("reader {}", i))
+				.spawn(move || reader(db, shutdown))
+				.unwrap(),
 		);
 	}
 
-	for i in 0 .. args.writers {
+	for i in 0..args.writers {
 		let db = db.clone();
 		let shutdown = shutdown.clone();
 		let pool = pool.clone();
@@ -274,9 +290,9 @@ pub fn run_internal<D: BenchDb>(args: Args, db: D) {
 
 		threads.push(
 			thread::Builder::new()
-			.name(format!("writer {}", i))
-			.spawn(move || writer(db, args, pool, shutdown, start_commit))
-			.unwrap()
+				.name(format!("writer {}", i))
+				.spawn(move || writer(db, args, pool, shutdown, start_commit))
+				.unwrap(),
 		);
 	}
 
@@ -297,32 +313,28 @@ pub fn run_internal<D: BenchDb>(args: Args, db: D) {
 		"Completed {} commits in {} seconds. {} cps",
 		commits,
 		elapsed,
-		commits as f64  / elapsed
+		commits as f64 / elapsed
 	);
 
 	if args.no_check {
-		return;
+		return
 	}
 
 	// Verify content
 	let start = std::time::Instant::now();
 	let pruned_per_commit = if args.archive { 0u64 } else { COMMIT_PRUNE_SIZE as u64 };
 	let mut queries = 0;
-	for nc in start_commit as u64 .. (start_commit + commits) as u64 {
+	for nc in start_commit as u64..(start_commit + commits) as u64 {
 		let counter = nc - start_commit as u64;
 		if counter % 1000 == 0 {
-			println!(
-				"Query {}/{}",
-				counter,
-				commits,
-			);
+			println!("Query {}/{}", counter, commits,);
 		}
-		let commits  = (start_commit + commits) as u64;
+		let commits = (start_commit + commits) as u64;
 		let prune_window: u64 = COMMIT_PRUNE_WINDOW as u64;
 		let offset = args.seed.unwrap_or(0);
 		let start = if !args.archive && commits > prune_window && nc < commits - prune_window {
 			let end = nc * COMMIT_SIZE as u64 + pruned_per_commit + offset;
-			for key in (nc * COMMIT_SIZE as u64) + offset .. end {
+			for key in (nc * COMMIT_SIZE as u64) + offset..end {
 				let k = pool.key(key);
 				let db_val = db.get(&k);
 				queries += 1;
@@ -332,7 +344,7 @@ pub fn run_internal<D: BenchDb>(args: Args, db: D) {
 		} else {
 			nc * COMMIT_SIZE as u64 + offset
 		};
-		for key in start .. (nc + 1) * (COMMIT_SIZE as u64) + offset {
+		for key in start..(nc + 1) * (COMMIT_SIZE as u64) + offset {
 			let k = pool.key(key);
 			let val = pool.value(key, args.compress);
 			let db_val = db.get(&k);
@@ -346,6 +358,6 @@ pub fn run_internal<D: BenchDb>(args: Args, db: D) {
 		"Completed {} queries in {} seconds. {} qps",
 		queries,
 		elapsed,
-		queries as f64  / elapsed
+		queries as f64 / elapsed
 	);
 }

--- a/admin/src/bench/sizes.rs
+++ b/admin/src/bench/sizes.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 /// Kusama value size distribution
-pub const KUSAMA_STATE_DISTRIBUTION: &'static[(u32, u32)] = &[
+pub const KUSAMA_STATE_DISTRIBUTION: &'static [(u32, u32)] = &[
 	(32, 35),
 	(33, 20035),
 	(34, 5369),

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -24,7 +24,6 @@ mod bench;
 /// Command line admin client entry point.
 /// Uses default column definition.
 pub fn run() -> Result<(), String> {
-
 	let cli = Cli::from_args();
 	use env_logger::Builder;
 
@@ -36,11 +35,15 @@ pub fn run() -> Result<(), String> {
 	builder.parse_filters(logs.as_slice().join(",").as_str());
 	builder.init();
 
-	let db_path = cli.shared().base_path.clone()
+	let db_path = cli
+		.shared()
+		.base_path
+		.clone()
 		.unwrap_or_else(|| std::env::current_dir().expect("Cannot resolve current dir"));
 	let nb_column = cli.shared().columns.unwrap_or(1);
 	let mut options = if let Some(metadata) = parity_db::Options::load_metadata(&db_path)
-		.map_err(|e| format!("Error resolving metas: {:?}", e))? {
+		.map_err(|e| format!("Error resolving metas: {:?}", e))?
+	{
 		let mut options = parity_db::Options::with_columns(db_path.as_path(), 0);
 		options.columns = metadata.columns;
 		options.salt = Some(metadata.salt);
@@ -78,9 +81,11 @@ pub fn run() -> Result<(), String> {
 			let dest_columns = dest_meta.columns;
 
 			if args.clear_dest && std::fs::metadata(&args.dest_path).is_ok() {
-				std::fs::remove_dir_all(&args.dest_path).map_err(|e| format!("Error removing dest dir: {:?}", e))?;
+				std::fs::remove_dir_all(&args.dest_path)
+					.map_err(|e| format!("Error removing dest dir: {:?}", e))?;
 			}
-			std::fs::create_dir_all(&args.dest_path).map_err(|e| format!("Error creating dest dir: {:?}", e))?;
+			std::fs::create_dir_all(&args.dest_path)
+				.map_err(|e| format!("Error creating dest dir: {:?}", e))?;
 
 			let mut dest_options = Options::with_columns(&args.dest_path, dest_columns.len() as u8);
 			dest_options.columns = dest_columns;
@@ -91,7 +96,8 @@ pub fn run() -> Result<(), String> {
 				.map_err(|e| format!("Migration error: {:?}", e))?;
 
 			if args.overwrite && std::fs::metadata(&args.dest_path).is_ok() {
-				std::fs::remove_dir_all(&args.dest_path).map_err(|e| format!("Error removing dest dir: {:?}", e))?;
+				std::fs::remove_dir_all(&args.dest_path)
+					.map_err(|e| format!("Error removing dest dir: {:?}", e))?;
 			}
 		},
 		SubCommand::Check(check) => {
@@ -99,7 +105,7 @@ pub fn run() -> Result<(), String> {
 				.map_err(|e| format!("Invalid db: {:?}", e))?;
 			if !check.index_value {
 				// Note that we should use enum parameter instead.
-				return Err("Requires one of the following check flag: --index-value".to_string());
+				return Err("Requires one of the following check flag: --index-value".to_string())
 			}
 			let check_param = parity_db::CheckOptions::new(
 				check.column,
@@ -108,15 +114,12 @@ pub fn run() -> Result<(), String> {
 				check.display,
 				check.display_value_max,
 			);
-			db.dump(check_param)
-				.map_err(|e| format!("Check error: {:?}", e))?;
+			db.dump(check_param).map_err(|e| format!("Check error: {:?}", e))?;
 		},
 		SubCommand::Flush(_flush) => {
-			let _db = parity_db::Db::open(&options)
-				.map_err(|e| format!("Invalid db: {:?}", e))?;
+			let _db = parity_db::Db::open(&options).map_err(|e| format!("Invalid db: {:?}", e))?;
 		},
 		SubCommand::Stress(bench) => {
-
 			let args = bench.get_args();
 			// avoid deleting folders by mistake.
 			options.path.push("test_db_stress");
@@ -165,7 +168,6 @@ pub struct Shared {
 /// Admin cli command for parity-db.
 #[derive(Debug, StructOpt)]
 pub struct Cli {
-
 	/// Subcommands.
 	#[structopt(subcommand)]
 	pub subcommand: SubCommand,
@@ -175,9 +177,7 @@ pub struct Cli {
 	/// The node will be started with the authority role and actively
 	/// participate in any consensus task that it can (e.g. depending on
 	/// availability of local keys).
-	#[structopt(
-		long = "validator"
-	)]
+	#[structopt(long = "validator")]
 	pub validator: bool,
 }
 
@@ -208,21 +208,11 @@ impl SubCommand {
 impl Cli {
 	fn shared(&self) -> &Shared {
 		match &self.subcommand {
-			SubCommand::Stats(stats) => {
-				&stats.shared
-			},
-			SubCommand::Migrate(stats) => {
-				&stats.shared
-			},
-			SubCommand::Flush(flush) => {
-				&flush.shared
-			},
-			SubCommand::Check(check) => {
-				&check.shared
-			},
-			SubCommand::Stress(bench) => {
-				&bench.shared
-			},
+			SubCommand::Stats(stats) => &stats.shared,
+			SubCommand::Migrate(stats) => &stats.shared,
+			SubCommand::Flush(flush) => &flush.shared,
+			SubCommand::Check(check) => &check.shared,
+			SubCommand::Stress(bench) => &bench.shared,
 		}
 	}
 }

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -18,7 +18,7 @@
 //! Experimental, some functionality may not
 //! guarantee db durability.
 
-#[cfg_attr(any(target_os = "linux", target_os = "macos"),  global_allocator)]
+#[cfg_attr(any(target_os = "linux", target_os = "macos"), global_allocator)]
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,23 @@
+# Basic
+hard_tabs = true
+max_width = 100
+use_small_heuristics = "Max"
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+# Consistency
+newline_style = "Unix"
+# Format comments
+comment_width = 100
+wrap_comments = true
+# Misc
+chain_width = 80
+spaces_around_ranges = false
+binop_separator = "Back"
+reorder_impl_items = false
+match_arm_leading_pipes = "Preserve"
+match_arm_blocks = false
+match_block_trailing_comma = true
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -62,12 +62,12 @@ impl BTree {
 		let mut root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), btree, log)?;
 		let changes = &mut changes;
 
-		while changes.len() > 0 {
+		while !changes.is_empty() {
 			match root.change(None, self.depth, changes, btree, log)? {
 				(Some((sep, right)), _) => {
 					// add one level
 					self.depth += 1;
-					let left = std::mem::replace(&mut root, Node::new());
+					let left = std::mem::take(&mut root);
 					let left_index = self.root_index.take();
 					let new_index = BTreeTable::write_node_plan(
 						btree,
@@ -137,7 +137,7 @@ impl BTree {
 
 	pub fn fetch_root(root: Address, tables: TablesRef, log: &impl LogQuery) -> Result<Node> {
 		Ok(if root == NULL_ADDRESS {
-			Node::new()
+			Node::default()
 		} else {
 			let root = BTreeTable::get_encoded_entry(root, log, tables)?;
 			Node::from_encoded(root)

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -17,11 +17,13 @@
 //! Btree overlay definition and methods.
 
 use super::*;
-use crate::table::key::TableKeyQuery;
-use crate::log::{LogWriter, LogQuery};
-use crate::column::Column;
-use crate::error::Result;
-use crate::btree::BTreeTable;
+use crate::{
+	btree::BTreeTable,
+	column::Column,
+	error::Result,
+	log::{LogQuery, LogWriter},
+	table::key::TableKeyQuery,
+};
 
 pub struct BTree {
 	pub(super) depth: u32,
@@ -31,25 +33,14 @@ pub struct BTree {
 
 impl BTree {
 	pub fn new(root_index: Option<Address>, depth: u32, record_id: u64) -> Self {
-		BTree {
-			root_index,
-			depth,
-			record_id,
-		}
+		BTree { root_index, depth, record_id }
 	}
 
-	pub fn open(
-		values: TablesRef,
-		log: &impl LogQuery,
-		record_id: u64,
-	) -> Result<Self> {
+	pub fn open(values: TablesRef, log: &impl LogQuery, record_id: u64) -> Result<Self> {
 		let btree_header = BTreeTable::btree_header(log, values)?;
 
-		let root_index = if btree_header.root == NULL_ADDRESS {
-			None
-		} else {
-			Some(btree_header.root)
-		};
+		let root_index =
+			if btree_header.root == NULL_ADDRESS { None } else { Some(btree_header.root) };
 		Ok(btree::BTree::new(root_index, btree_header.depth, record_id))
 	}
 
@@ -69,47 +60,28 @@ impl BTree {
 					self.depth += 1;
 					let left = std::mem::take(&mut root);
 					let left_index = self.root_index.take();
-					let new_index = BTreeTable::write_node_plan(
-						btree,
-						left,
-						log,
-						left_index,
-					)?;
-					let new_index = if new_index.is_some() {
-						new_index
-					} else {
-						left_index
-					};
+					let new_index = BTreeTable::write_node_plan(btree, left, log, left_index)?;
+					let new_index = if new_index.is_some() { new_index } else { left_index };
 					root.set_child(0, Node::new_child(new_index));
 					root.set_child(1, right);
 					root.set_separator(0, sep);
 				},
-				(_, true) => {
+				(_, true) =>
 					if let Some((node_index, node)) = root.need_remove_root(btree, log)? {
 						self.depth -= 1;
 						if let Some(index) = self.root_index.take() {
-							BTreeTable::write_plan_remove_node(
-								btree,
-								log,
-								index,
-							)?;
+							BTreeTable::write_plan_remove_node(btree, log, index)?;
 						}
 						self.root_index = node_index;
 						root = node;
-					}
-				},
+					},
 				_ => (),
 			}
 			*changes = &changes[1..];
 		}
 
 		if root.changed {
-			let new_index = BTreeTable::write_node_plan(
-				btree,
-				root,
-				log,
-				self.root_index,
-			)?;
+			let new_index = BTreeTable::write_node_plan(btree, root, log, self.root_index)?;
 
 			if new_index.is_some() {
 				self.root_index = new_index;
@@ -124,7 +96,12 @@ impl BTree {
 		root.is_balanced(tables, log, 0)
 	}
 
-	pub fn get(&self, key: &[u8], values: TablesRef, log: &impl LogQuery) -> Result<Option<Vec<u8>>> {
+	pub fn get(
+		&self,
+		key: &[u8],
+		values: TablesRef,
+		log: &impl LogQuery,
+	) -> Result<Option<Vec<u8>>> {
 		let root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), values, log)?;
 		if let Some(address) = root.get(key, values, log)? {
 			let key_query = TableKeyQuery::Fetch(None);

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -14,21 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-
 /// BTree iterator implementation.
 /// This does not enforce consistency.
 /// If a commit did happen after an
 /// iterator is created, the iterator will
 /// just replay a `seek` operation at its
 /// latest accessed key.u
-
 use super::*;
-use crate::db::CommitOverlay;
-use crate::table::key::TableKeyQuery;
-use crate::log::LogQuery;
-use crate::error::Result;
+use crate::{
+	btree::BTreeTable, db::CommitOverlay, error::Result, log::LogQuery, table::key::TableKeyQuery,
+};
 use parking_lot::RwLock;
-use crate::btree::BTreeTable;
 
 pub struct BTreeIterator<'a> {
 	table: &'a BTreeTable,
@@ -46,7 +42,7 @@ pub struct BtreeIterBackend(BTree, BTreeIterState);
 impl<'a> BTreeIterator<'a> {
 	pub(crate) fn new(
 		table: &'a BTreeTable,
-		col: ColId, 
+		col: ColId,
 		log: &'a RwLock<crate::log::LogOverlays>,
 		commit_overlay: &'a RwLock<Vec<CommitOverlay>>,
 	) -> Result<Self> {
@@ -83,7 +79,8 @@ impl<'a> BTreeIterator<'a> {
 		let log = self.log.read();
 		let record_id = log.last_record_id(self.col);
 		let commit_overlay = self.commit_overlay.read();
-		let next_commit_overlay = commit_overlay.get(col as usize)
+		let next_commit_overlay = commit_overlay
+			.get(col as usize)
 			.and_then(|o| o.btree_next(&self.last_key, self.from_seek));
 		// No consistency over iteration, allows dropping lock to overlay.
 		std::mem::drop(commit_overlay);
@@ -97,9 +94,9 @@ impl<'a> BTreeIterator<'a> {
 		};
 
 		match (next_commit_overlay, next_backend) {
-			(Some((commit_key, commit_value)), Some((backend_key, backend_value))) => {
+			(Some((commit_key, commit_value)), Some((backend_key, backend_value))) =>
 				match commit_key.cmp(&backend_key) {
-					std::cmp::Ordering::Less => {
+					std::cmp::Ordering::Less =>
 						if let Some(value) = commit_value {
 							self.last_key = Some(commit_key.clone());
 							self.from_seek = false;
@@ -111,13 +108,12 @@ impl<'a> BTreeIterator<'a> {
 							self.pending_next_backend = Some(Some((backend_key, backend_value)));
 							std::mem::drop(log);
 							self.next()
-						}
-					},
+						},
 					std::cmp::Ordering::Greater => {
 						self.last_key = Some(backend_key.clone());
 						Ok(Some((backend_key, backend_value)))
 					},
-					std::cmp::Ordering::Equal => {
+					std::cmp::Ordering::Equal =>
 						if let Some(value) = commit_value {
 							self.last_key = Some(commit_key);
 							self.from_seek = false;
@@ -127,11 +123,9 @@ impl<'a> BTreeIterator<'a> {
 							self.from_seek = false;
 							std::mem::drop(log);
 							self.next()
-						}
-					},
-				}
-			},
-			(Some((commit_key, commit_value)), None) => {
+						},
+				},
+			(Some((commit_key, commit_value)), None) =>
 				if let Some(value) = commit_value {
 					self.last_key = Some(commit_key.clone());
 					self.from_seek = false;
@@ -143,8 +137,7 @@ impl<'a> BTreeIterator<'a> {
 					self.pending_next_backend = Some(None);
 					std::mem::drop(log);
 					self.next()
-				}
-			},
+				},
 			(None, Some((backend_key, backend_value))) => {
 				self.last_key = Some(backend_key.clone());
 				Ok(Some((backend_key, backend_value)))
@@ -156,7 +149,12 @@ impl<'a> BTreeIterator<'a> {
 		}
 	}
 
-	pub fn next_backend(&mut self, record_id: u64, col: &BTreeTable, log: &impl LogQuery) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+	pub fn next_backend(
+		&mut self,
+		record_id: u64,
+		col: &BTreeTable,
+		log: &impl LogQuery,
+	) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
 		let BtreeIterBackend(tree, iter) = &mut self.iter;
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, log, record_id))?;
@@ -169,7 +167,14 @@ impl<'a> BTreeIterator<'a> {
 		iter.next(tree, col, log)
 	}
 
-	pub fn seek_backend(&mut self, key: &[u8], record_id: u64, col: &BTreeTable, log: &impl LogQuery, after: bool) -> Result<()> {
+	pub fn seek_backend(
+		&mut self,
+		key: &[u8],
+		record_id: u64,
+		col: &BTreeTable,
+		log: &impl LogQuery,
+		after: bool,
+	) -> Result<()> {
 		let BtreeIterBackend(tree, iter) = &mut self.iter;
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, log, record_id))?;
@@ -188,11 +193,7 @@ pub struct BTreeIterState {
 
 impl BTreeIterState {
 	pub fn new(record_id: u64) -> BTreeIterState {
-		BTreeIterState {
-			next_separator: false,
-			state: vec![],
-			record_id,
-		}
+		BTreeIterState { next_separator: false, state: vec![], record_id }
 	}
 
 	pub fn next(
@@ -202,7 +203,7 @@ impl BTreeIterState {
 		log: &impl LogQuery,
 	) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
 		if self.next_separator && self.state.is_empty() {
-			return Ok(None);
+			return Ok(None)
 		}
 		if !self.next_separator {
 			if self.state.is_empty() {
@@ -212,12 +213,10 @@ impl BTreeIterState {
 				self.state.push((0, root));
 			}
 			while let Some((ix, node)) = self.state.last_mut() {
-				if let Some(child) = col.with_locked(|btree| {
-					node.fetch_child(*ix, btree, log)
-				})? {
+				if let Some(child) = col.with_locked(|btree| node.fetch_child(*ix, btree, log))? {
 					self.state.push((0, child));
 				} else {
-					break;
+					break
 				}
 			}
 			self.next_separator = true;
@@ -232,7 +231,7 @@ impl BTreeIterState {
 
 					let key_query = TableKeyQuery::Fetch(None);
 					let r = col.get_at_value_index(key_query, address, log)?;
-					return Ok(r.map(|r| (key, r.1)));
+					return Ok(r.map(|r| (key, r.1)))
 				}
 			}
 		}
@@ -241,7 +240,14 @@ impl BTreeIterState {
 		self.next(btree, col, log)
 	}
 
-	pub fn seek(&mut self, key: &[u8], btree: &mut BTree, col: &BTreeTable, log: &impl LogQuery, after: bool) -> Result<()> {
+	pub fn seek(
+		&mut self,
+		key: &[u8],
+		btree: &mut BTree,
+		col: &BTreeTable,
+		log: &impl LogQuery,
+		after: bool,
+	) -> Result<()> {
 		self.state.clear();
 		self.next_separator = false;
 		if col.with_locked(|b| {

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -104,29 +104,29 @@ impl<'a> BTreeIterator<'a> {
 							self.last_key = Some(commit_key.clone());
 							self.from_seek = false;
 							self.pending_next_backend = Some(Some((backend_key, backend_value)));
-							return Ok(Some((commit_key, value)));
+							Ok(Some((commit_key, value)))
 						} else {
 							self.last_key = Some(commit_key);
 							self.from_seek = false;
 							self.pending_next_backend = Some(Some((backend_key, backend_value)));
 							std::mem::drop(log);
-							return self.next();
+							self.next()
 						}
 					},
 					std::cmp::Ordering::Greater => {
 						self.last_key = Some(backend_key.clone());
-						return Ok(Some((backend_key, backend_value)));
+						Ok(Some((backend_key, backend_value)))
 					},
 					std::cmp::Ordering::Equal => {
 						if let Some(value) = commit_value {
 							self.last_key = Some(commit_key);
 							self.from_seek = false;
-							return Ok(Some((backend_key, value)));
+							Ok(Some((backend_key, value)))
 						} else {
 							self.last_key = Some(commit_key);
 							self.from_seek = false;
 							std::mem::drop(log);
-							return self.next();
+							self.next()
 						}
 					},
 				}
@@ -136,22 +136,22 @@ impl<'a> BTreeIterator<'a> {
 					self.last_key = Some(commit_key.clone());
 					self.from_seek = false;
 					self.pending_next_backend = Some(None);
-					return Ok(Some((commit_key, value)));
+					Ok(Some((commit_key, value)))
 				} else {
 					self.last_key = Some(commit_key);
 					self.from_seek = false;
 					self.pending_next_backend = Some(None);
 					std::mem::drop(log);
-					return self.next();
+					self.next()
 				}
 			},
 			(None, Some((backend_key, backend_value))) => {
 				self.last_key = Some(backend_key.clone());
-				return Ok(Some((backend_key, backend_value)));
+				Ok(Some((backend_key, backend_value)))
 			},
 			(None, None) => {
 				self.pending_next_backend = Some(None);
-				return Ok(None);
+				Ok(None)
 			},
 		}
 	}

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -468,7 +468,7 @@ pub mod commit_overlay {
 			let old_btree_header = btree_header.clone();
 
 			self.changes.sort_by_key(|(k, _)| k.clone());
-			tree.write_sorted_changes(&mut self.changes.as_slice(), locked, writer)?;
+			tree.write_sorted_changes(self.changes.as_slice(), locked, writer)?;
 			*ops += self.changes.len() as u64;
 			BTreeTable::write_plan(locked, &mut tree, writer, record_id, &mut btree_header)?;
 

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -33,23 +33,26 @@
 //
 // This sequence is repeated ORDER times, followed by an additional CHILD index.
 
-use node::SeparatorInner;
-use crate::table::{Entry as ValueTableEntry, ValueTable, Value};
-use crate::table::key::{TableKey, TableKeyQuery};
-use crate::options::Options;
-use crate::index::Address;
-use crate::error::{Error, Result};
-use crate::column::{ColId, Column, TablesRef};
-use crate::log::{LogQuery, LogWriter, LogAction, LogReader};
-use crate::compress::Compress;
-use crate::btree::node::Node;
-use crate::btree::btree::BTree;
-use parking_lot::RwLock;
+use crate::{
+	btree::{btree::BTree, node::Node},
+	column::{ColId, Column, TablesRef},
+	compress::Compress,
+	error::{Error, Result},
+	index::Address,
+	log::{LogAction, LogQuery, LogReader, LogWriter},
+	options::Options,
+	table::{
+		key::{TableKey, TableKeyQuery},
+		Entry as ValueTableEntry, Value, ValueTable,
+	},
+};
 pub use iter::BTreeIterator;
+use node::SeparatorInner;
+use parking_lot::RwLock;
 
 mod btree;
-mod node;
 mod iter;
+mod node;
 
 const ORDER: usize = 8;
 const ORDER_CHILD: usize = ORDER + 1;
@@ -77,41 +80,32 @@ impl Entry {
 	}
 
 	fn from_encoded(enc: Vec<u8>) -> Self {
-		Entry {
-			encoded: ValueTableEntry::new(enc),
-		}
+		Entry { encoded: ValueTableEntry::new(enc) }
 	}
 
 	fn read_separator(&mut self) -> Option<SeparatorInner> {
 		if self.encoded.offset() == self.encoded.inner_mut().len() {
-			return None;
+			return None
 		}
 		let value = self.encoded.read_u64();
 		let head = self.encoded.read_slice(1);
 		let head = head[0];
-		let size = if head == u8::MAX {
-			self.encoded.read_u32() as usize
-		} else {
-			head as usize
-		};
+		let size = if head == u8::MAX { self.encoded.read_u32() as usize } else { head as usize };
 		let key = self.encoded.read_slice(size).to_vec();
 		if value == 0 {
-			return None;
+			return None
 		}
 		let value = Address::from_u64(value);
-		Some(SeparatorInner {
-			key,
-			value,
-		})
+		Some(SeparatorInner { key, value })
 	}
 
 	fn write_separator(&mut self, key: &Vec<u8>, value: Address) {
 		let size = key.len();
 		let inner_size = self.encoded.inner_mut().len();
 		if size >= u8::MAX as usize {
-			self.encoded.inner_mut().resize(inner_size + 8 + 1 + 4 + size, 0); 
+			self.encoded.inner_mut().resize(inner_size + 8 + 1 + 4 + size, 0);
 		} else {
-			self.encoded.inner_mut().resize(inner_size + 8 + 1 + size, 0); 
+			self.encoded.inner_mut().resize(inner_size + 8 + 1 + size, 0);
 		};
 		self.encoded.write_u64(value.as_u64());
 		if size >= u8::MAX as usize {
@@ -161,10 +155,7 @@ impl BTreeTable {
 	) -> Result<Self> {
 		let size_tier = HEADER_ADDRESS.size_tier() as usize;
 		if !values[size_tier].is_init() {
-			let btree_header = BTreeHeader {
-				root: NULL_ADDRESS,
-				depth: 0,
-			};
+			let btree_header = BTreeHeader { root: NULL_ADDRESS, depth: 0 };
 			let mut entry = Entry::empty();
 			entry.write_header(&btree_header);
 			values[size_tier].init_with_entry(&*entry.encoded.inner_mut())?;
@@ -187,13 +178,15 @@ impl BTreeTable {
 			root = Address::from_u64(buf.read_u64());
 			depth = buf.read_u32();
 		}
-		Ok(BTreeHeader {
-			root,
-			depth,
-		})
+		Ok(BTreeHeader { root, depth })
 	}
 
-	fn get_at_value_index(&self, key: TableKeyQuery, address: Address, log: &impl LogQuery) -> Result<Option<(u8, Value)>> {
+	fn get_at_value_index(
+		&self,
+		key: TableKeyQuery,
+		address: Address,
+		log: &impl LogQuery,
+	) -> Result<Option<(u8, Value)>> {
 		let tables = self.tables.read();
 		let btree = self.locked(&*tables);
 		Column::get_value(key, address, btree, log)
@@ -210,10 +203,10 @@ impl BTreeTable {
 	pub fn get(key: &[u8], log: &impl LogQuery, values: TablesRef) -> Result<Option<Vec<u8>>> {
 		let btree_header = Self::btree_header(log, values)?;
 		if btree_header.root == NULL_ADDRESS {
-			return Ok(None);
+			return Ok(None)
 		}
 		let record_id = 0; // lifetime of Btree is the query, so no invalidate.
-		// keeping log locked when parsing tree.
+				   // keeping log locked when parsing tree.
 		let tree = BTree::new(Some(btree_header.root), btree_header.depth, record_id);
 		tree.get(key, values, log)
 	}
@@ -262,7 +255,7 @@ impl BTreeTable {
 			},
 			_ => {
 				log::error!(target: "parity-db", "Unexpected log action");
-				return Err(Error::Corruption("Unexpected log action".to_string()));
+				return Err(Error::Corruption("Unexpected log action".to_string()))
 			},
 		}
 		Ok(())
@@ -336,7 +329,7 @@ impl BTreeTable {
 		}
 
 		if !node.changed {
-			return Ok(None);
+			return Ok(None)
 		}
 
 		let mut entry = Entry::empty();
@@ -350,13 +343,13 @@ impl BTreeTable {
 			}
 			i_children += 1;
 			if i_children == ORDER_CHILD {
-				break;
+				break
 			}
 			if let Some(sep) = &node.separators.as_mut()[i_separator].separator {
 				entry.write_separator(&sep.key, sep.value);
 				i_separator += 1
 			} else {
-				break;
+				break
 			}
 		}
 
@@ -397,9 +390,11 @@ impl BTreeTable {
 
 pub mod commit_overlay {
 	use super::*;
-	use crate::db::BTreeCommitOverlay;
-	use crate::column::{Column, ColId};
-	use crate::error::Result;
+	use crate::{
+		column::{ColId, Column},
+		db::BTreeCommitOverlay,
+		error::Result,
+	};
 
 	pub struct BTreeChangeSet {
 		pub col: ColId,
@@ -416,7 +411,13 @@ pub mod commit_overlay {
 			self.changes.push((k.to_vec(), v));
 		}
 
-		pub fn copy_to_overlay(&self, overlay: &mut BTreeCommitOverlay, record_id: u64, bytes: &mut usize, options: &Options) {
+		pub fn copy_to_overlay(
+			&self,
+			overlay: &mut BTreeCommitOverlay,
+			record_id: u64,
+			bytes: &mut usize,
+			options: &Options,
+		) {
 			let ref_counted = options.columns[self.col as usize].ref_counted;
 			for commit in self.changes.iter() {
 				match commit {
@@ -461,10 +462,8 @@ pub mod commit_overlay {
 			let locked = btree.locked(&*locked_tables);
 			let mut tree = BTree::open(locked, writer, record_id)?;
 
-			let mut btree_header = BTreeHeader {
-				root: tree.root_index.unwrap_or(NULL_ADDRESS),
-				depth: tree.depth,
-			};
+			let mut btree_header =
+				BTreeHeader { root: tree.root_index.unwrap_or(NULL_ADDRESS), depth: tree.depth };
 			let old_btree_header = btree_header.clone();
 
 			self.changes.sort_by_key(|(k, _)| k.clone());

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -17,12 +17,14 @@
 //! BTree node struct and methods.
 
 use super::*;
-use crate::table::key::TableKey;
+use crate::{
+	column::Column,
+	error::Result,
+	index::Address,
+	log::{LogQuery, LogWriter},
+	table::key::TableKey,
+};
 use std::cmp::Ordering;
-use crate::log::{LogWriter, LogQuery};
-use crate::column::Column;
-use crate::error::Result;
-use crate::index::Address;
 
 impl Node {
 	fn last_separator_index(&self) -> Option<usize> {
@@ -43,12 +45,7 @@ impl Node {
 	) -> Result<()> {
 		if child.changed {
 			let child_index = self.children[i].entry_index;
-			let new_index = BTreeTable::write_node_plan(
-				btree,
-				child,
-				log,
-				child_index,
-			)?;
+			let new_index = BTreeTable::write_node_plan(btree, child, log, child_index)?;
 			if new_index.is_some() {
 				self.changed = true;
 				self.children[i].entry_index = new_index;
@@ -63,17 +60,8 @@ impl Node {
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<Child> {
-		let new_index = BTreeTable::write_node_plan(
-			btree,
-			right,
-			log,
-			right_ix,
-		)?;
-		let right_ix = if new_index.is_some() {
-			new_index
-		} else {
-			right_ix
-		};
+		let new_index = BTreeTable::write_node_plan(btree, right, log, right_ix)?;
+		let right_ix = if new_index.is_some() { new_index } else { right_ix };
 		Ok(Self::new_child(right_ix))
 	}
 
@@ -87,9 +75,10 @@ impl Node {
 	) -> Result<(Option<(Separator, Child)>, bool)> {
 		loop {
 			if changes.len() > 1 {
-				if changes[0].0 == changes[1].0 { // TODO only when advancing (here rec call useless)
+				if changes[0].0 == changes[1].0 {
+					// TODO only when advancing (here rec call useless)
 					*changes = &changes[1..];
-					continue;
+					continue
 				}
 				debug_assert!(changes[0].0 < changes[1].0);
 			}
@@ -100,28 +89,28 @@ impl Node {
 				self.remove(depth, key, changes, btree, log)?
 			};
 			if r.0.is_some() || r.1 {
-				return Ok(r);
+				return Ok(r)
 			}
 			if changes.len() == 1 {
-				break;
+				break
 			}
 			if let Some((parent, p)) = &parent {
 				let key = &changes[1].0;
 				let (at, i) = self.position(key)?; // TODO could start position from current
 				if at || i < self.number_separator() {
 					*changes = &changes[1..];
-					continue;
+					continue
 				}
 				let (at, i) = parent.position(key)?;
 				if !at && &i == p && i < parent.number_separator() {
 					*changes = &changes[1..];
-					continue;
+					continue
 				}
 				// Could check other parents for case i == parent.number_separator.
 				// Would mean unsafe Vec<*mut>, or other complex design: skipping
 				// this case.
 			}
-			break;
+			break
 		}
 		Ok((None, false))
 	}
@@ -157,7 +146,7 @@ impl Node {
 					}
 				} else {
 					(None, false)
-				});
+				})
 			}
 
 			if self.has_separator(ORDER - 1) {
@@ -169,19 +158,25 @@ impl Node {
 				if insert == middle {
 					let (right, right_ix) = self.split(middle, true, None, None, has_child);
 					let right = Self::write_split_child(right_ix, right, btree, log)?;
-					return Ok((Some((insert_separator, right)), false));
+					return Ok((Some((insert_separator, right)), false))
 				} else if insert < middle {
 					let (right, right_ix) = self.split(middle, false, None, None, has_child);
 					let sep = self.remove_separator(middle - 1);
 					self.shift_from(insert, has_child, false);
 					self.set_separator(insert, insert_separator);
 					let right = Self::write_split_child(right_ix, right, btree, log)?;
-					return Ok((Some((sep, right)), false));
+					return Ok((Some((sep, right)), false))
 				} else {
-					let (right, right_ix) = self.split(middle + 1, false, Some((insert, insert_separator)), None, has_child);
+					let (right, right_ix) = self.split(
+						middle + 1,
+						false,
+						Some((insert, insert_separator)),
+						None,
+						has_child,
+					);
 					let sep = self.remove_separator(middle);
 					let right = Self::write_split_child(right_ix, right, btree, log)?;
-					return Ok((Some((sep, right)), false));
+					return Ok((Some((sep, right)), false))
 				}
 			}
 
@@ -224,7 +219,13 @@ impl Node {
 				let right = Self::write_split_child(right_ix, right, btree, log)?;
 				Ok(Some((sep, right)))
 			} else {
-				let (right, right_ix) = self.split(middle + 1, false, Some((insert, separator)), Some((insert, child)), has_child);
+				let (right, right_ix) = self.split(
+					middle + 1,
+					false,
+					Some((insert, separator)),
+					Some((insert, child)),
+					has_child,
+				);
 				let sep = self.remove_separator(middle);
 				let right = Self::write_split_child(right_ix, right, btree, log)?;
 				Ok(Some((sep, right)))
@@ -277,7 +278,7 @@ impl Node {
 			}
 		} else {
 			if !has_child {
-				return Ok((None, false));
+				return Ok((None, false))
 			}
 			if let Some(mut child) = self.fetch_child(i, values, log)? {
 				let r = child.change(Some((self, i)), depth - 1, changes, values, log)?;
@@ -292,9 +293,9 @@ impl Node {
 						(None, self.need_rebalance())
 					},
 					r => r,
-				});
+				})
 			} else {
-				return Ok((None, false));
+				return Ok((None, false))
 			}
 		}
 
@@ -338,7 +339,7 @@ impl Node {
 			right.set_separator(0, separator);
 			self.write_child(at - 1, left, values, log)?;
 			self.write_child(at, right, values, log)?;
-			return Ok(());
+			return Ok(())
 		}
 
 		let number_child = self.number_separator() + 1;
@@ -371,7 +372,7 @@ impl Node {
 			}
 			self.write_child(at, left, values, log)?;
 			self.write_child(at + 1, right, values, log)?;
-			return Ok(());
+			return Ok(())
 		}
 
 		let (at, at_right) = if at + 1 == number_child {
@@ -413,11 +414,7 @@ impl Node {
 
 		let removed = self.remove_child(at_right);
 		if let Some(index) = removed.entry_index {
-			BTreeTable::write_plan_remove_node(
-				values,
-				log,
-				index,
-			)?;
+			BTreeTable::write_plan_remove_node(values, log, index)?;
 		}
 		self.write_child(at, left, values, log)?;
 		self.write_child(at_right, right, values, log)?;
@@ -437,11 +434,11 @@ impl Node {
 		log: &mut LogWriter,
 	) -> Result<Option<(Option<Address>, Node)>> {
 		if self.number_separator() == 0 && self.fetch_child(0, values, log)?.is_some() {
-            if let Some(node) = self.fetch_child(0, values, log)? {
-                let child = self.remove_child(0);
-                return Ok(Some((child.entry_index, node)))
-            }
-        }
+			if let Some(node) = self.fetch_child(0, values, log)? {
+				let child = self.remove_child(0);
+				return Ok(Some((child.entry_index, node)))
+			}
+		}
 		Ok(None)
 	}
 
@@ -454,7 +451,7 @@ impl Node {
 		let last = if let Some(last) = self.last_separator_index() {
 			last
 		} else {
-			return Ok((false, None));
+			return Ok((false, None))
 		};
 		let i = last;
 		if depth == 0 {
@@ -462,33 +459,45 @@ impl Node {
 
 			Ok((self.need_rebalance(), Some(result)))
 		} else if let Some(mut child) = self.fetch_child(i + 1, values, log)? {
-            let result = child.remove_last(depth - 1, values, log)?;
-            self.write_child(i + 1, child, values, log)?;
-            if result.0 {
-                self.rebalance(depth, i + 1, values, log)?;
-                Ok((self.need_rebalance(), result.1))
-            } else {
-                Ok(result)
-            }
-        } else {
-            Ok((false, None))
-  			}
+			let result = child.remove_last(depth - 1, values, log)?;
+			self.write_child(i + 1, child, values, log)?;
+			if result.0 {
+				self.rebalance(depth, i + 1, values, log)?;
+				Ok((self.need_rebalance(), result.1))
+			} else {
+				Ok(result)
+			}
+		} else {
+			Ok((false, None))
+		}
 	}
 
-	pub fn get(&self, key: &[u8], values: TablesRef, log: &impl LogQuery) -> Result<Option<Address>> {
+	pub fn get(
+		&self,
+		key: &[u8],
+		values: TablesRef,
+		log: &impl LogQuery,
+	) -> Result<Option<Address>> {
 		let (at, i) = self.position(key)?;
 		if at {
 			Ok(self.separator_address(i))
 		} else {
 			if let Some(child) = self.fetch_child(i, values, log)? {
-				return child.get(key, values, log);
+				return child.get(key, values, log)
 			}
 
 			Ok(None)
 		}
 	}
 
-	pub fn seek(from: Self, key: &[u8], values: TablesRef, log: &impl LogQuery, depth: u32, stack: &mut Vec<(usize, Self)>) -> Result<bool> {
+	pub fn seek(
+		from: Self,
+		key: &[u8],
+		values: TablesRef,
+		log: &impl LogQuery,
+		depth: u32,
+		stack: &mut Vec<(usize, Self)>,
+	) -> Result<bool> {
 		let (at, i) = from.position(key)?;
 		if at {
 			stack.push((i, from));
@@ -497,7 +506,7 @@ impl Node {
 			if depth != 0 {
 				if let Some(child) = from.fetch_child(i, values, log)? {
 					stack.push((i, from));
-					return Self::seek(child, key, values, log, depth - 1, stack);
+					return Self::seek(child, key, values, log, depth - 1, stack)
 				}
 			}
 			stack.push((i, from));
@@ -506,10 +515,15 @@ impl Node {
 	}
 
 	#[cfg(test)]
-	pub fn is_balanced(&self, tables: TablesRef, log: &impl LogQuery, parent_size: usize) -> Result<bool> {
+	pub fn is_balanced(
+		&self,
+		tables: TablesRef,
+		log: &impl LogQuery,
+		parent_size: usize,
+	) -> Result<bool> {
 		let size = self.number_separator();
 		if parent_size != 0 && size < ORDER / 2 {
-			return Ok(false);
+			return Ok(false)
 		}
 
 		let mut i = 0;
@@ -517,10 +531,10 @@ impl Node {
 			let child = self.fetch_child(i, tables, log)?;
 			i += 1;
 			if child.is_none() {
-				continue;
+				continue
 			}
 			if !child.unwrap().is_balanced(tables, log, size)? {
-				return Ok(false);
+				return Ok(false)
 			}
 		}
 
@@ -540,11 +554,7 @@ pub struct Node {
 
 impl Default for Node {
 	fn default() -> Self {
-		Node {
-			separators: Default::default(),
-			children: Default::default(),
-			changed: true,
-		}
+		Node { separators: Default::default(), children: Default::default(), changed: true }
 	}
 }
 
@@ -575,11 +585,8 @@ impl Node {
 
 	pub fn from_encoded(enc: Vec<u8>) -> Self {
 		let mut entry = Entry::from_encoded(enc);
-		let mut node = Node {
-			separators: Default::default(),
-			children: Default::default(),
-			changed: false,
-		};
+		let mut node =
+			Node { separators: Default::default(), children: Default::default(), changed: false };
 		let mut i_children = 0;
 		let mut i_separator = 0;
 		loop {
@@ -588,13 +595,13 @@ impl Node {
 			}
 			i_children += 1;
 			if i_children == ORDER_CHILD {
-				break;
+				break
 			}
 			if let Some(sep) = entry.read_separator() {
 				node.separators.as_mut()[i_separator].separator = Some(sep);
 				i_separator += 1
 			} else {
-				break;
+				break
 			}
 		}
 		node
@@ -602,20 +609,18 @@ impl Node {
 
 	pub fn remove_separator(&mut self, at: usize) -> Separator {
 		self.changed = true;
-		let mut separator = std::mem::replace(&mut self.separators[at], Separator {
-			modified: true,
-			separator: None,
-		});
+		let mut separator = std::mem::replace(
+			&mut self.separators[at],
+			Separator { modified: true, separator: None },
+		);
 		separator.modified = true;
 		separator
 	}
 
 	pub fn remove_child(&mut self, at: usize) -> Child {
 		self.changed = true;
-		let mut child = std::mem::replace(&mut self.children[at], Child {
-			moved: true,
-			entry_index: None,
-		});
+		let mut child =
+			std::mem::replace(&mut self.children[at], Child { moved: true, entry_index: None });
 		child.moved = true;
 		child
 	}
@@ -639,10 +644,7 @@ impl Node {
 	}
 
 	pub fn new_child(index: Option<Address>) -> Child {
-		Child {
-			moved: true,
-			entry_index: index,
-		}
+		Child { moved: true, entry_index: index }
 	}
 
 	pub fn set_child(&mut self, at: usize, mut child: Child) {
@@ -667,23 +669,13 @@ impl Node {
 				Some(value),
 				log,
 				None,
-			)?.1.unwrap_or(address)
-		} else {
-			Column::write_new_value_plan(
-				&TableKey::NoHash,
-				btree,
-				value,
-				log,
-				None,
 			)?
+			.1
+			.unwrap_or(address)
+		} else {
+			Column::write_new_value_plan(&TableKey::NoHash, btree, value, log, None)?
 		};
-		Ok(Separator {
-			modified: true,
-			separator: Some(SeparatorInner {
-				key,
-				value,
-			}),
-		})
+		Ok(Separator { modified: true, separator: Some(SeparatorInner { key, value }) })
 	}
 
 	fn split(
@@ -697,7 +689,7 @@ impl Node {
 		let (right_ix, mut right) = (None, Self::default());
 		let mut offset = 0;
 		let right_start = at;
-		for i in right_start .. ORDER {
+		for i in right_start..ORDER {
 			let sep = self.remove_separator(i);
 			if insert_right.as_ref().map(|ins| ins.0 == i).unwrap_or(false) {
 				if let Some((_, sep)) = insert_right.take() {
@@ -714,7 +706,7 @@ impl Node {
 		let mut offset = 0;
 		if has_child {
 			let skip_offset = if skip_left_child { 1 } else { 0 };
-			for i in right_start + skip_offset .. ORDER_CHILD {
+			for i in right_start + skip_offset..ORDER_CHILD {
 				let child = self.remove_child(i);
 				if insert_right_child.as_ref().map(|ins| ins.0 + 1 == i).unwrap_or(false) {
 					offset = 1;
@@ -742,22 +734,18 @@ impl Node {
 			current.modified = true;
 			i += 1;
 			if i == ORDER {
-				break;
+				break
 			}
 			current = std::mem::replace(&mut self.separators[i], current);
 		}
 		if has_child {
-			let mut i = if with_left_child {
-				from
-			} else {
-				from + 1
-			};
+			let mut i = if with_left_child { from } else { from + 1 };
 			let mut current = self.remove_child(i);
 			while current.entry_index.is_some() {
 				current.moved = true;
 				i += 1;
 				if i == ORDER_CHILD {
-					break;
+					break
 				}
 				current = std::mem::replace(&mut self.children[i], current);
 			}
@@ -771,20 +759,16 @@ impl Node {
 			self.separators.as_mut()[i] = self.remove_separator(i + 1);
 			self.separators.as_mut()[i].modified = true;
 			if self.separators.as_mut()[i].separator.is_none() {
-				break;
+				break
 			}
 			i += 1;
 		}
 		if has_child {
-			let mut i = if with_left_child {
-				from
-			} else {
-				from + 1
-			};
+			let mut i = if with_left_child { from } else { from + 1 };
 			while i < ORDER_CHILD - 1 {
 				self.children.as_mut()[i] = self.remove_child(i + 1);
 				if self.children.as_mut()[i].entry_index.is_none() {
-					break;
+					break
 				}
 				i += 1;
 			}
@@ -796,7 +780,7 @@ impl Node {
 		while self.separators[i].separator.is_some() {
 			i += 1;
 			if i == ORDER {
-				break;
+				break
 			}
 		}
 		i
@@ -810,24 +794,29 @@ impl Node {
 			match key[..].cmp(&separator.key[..]) {
 				Ordering::Greater => (),
 				Ordering::Less => {
-					return Ok((false, i));
+					return Ok((false, i))
 				},
 				Ordering::Equal => {
-					return Ok((true, i));
+					return Ok((true, i))
 				},
 			}
 			i += 1;
 			if i == ORDER {
-				break;
+				break
 			}
 		}
 		Ok((false, i))
 	}
 
-	pub fn fetch_child(&self, i: usize, values: TablesRef, log: &impl LogQuery) -> Result<Option<Self>> {
+	pub fn fetch_child(
+		&self,
+		i: usize,
+		values: TablesRef,
+		log: &impl LogQuery,
+	) -> Result<Option<Self>> {
 		if let Some(ix) = self.children[i].entry_index {
 			let entry = BTreeTable::get_encoded_entry(ix, log, values)?;
-			return Ok(Some(Self::from_encoded(entry)));
+			return Ok(Some(Self::from_encoded(entry)))
 		}
 		Ok(None)
 	}

--- a/src/column.rs
+++ b/src/column.rs
@@ -14,24 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, Ordering};
-use parking_lot::{RwLock, RwLockUpgradableReadGuard};
-use crate::table::SIZE_TIERS;
 use crate::{
-	Key,
-	table::key::{TableKeyQuery, TableKey},
-	error::{Error, Result},
-	table::{TableId as ValueTableId, ValueTable, Value},
-	log::{Log, LogOverlays, LogReader, LogWriter, LogAction, LogQuery},
-	display::hex,
-	index::{IndexTable, TableId as IndexTableId, PlanOutcome, Address},
-	options::{Options, ColumnOptions, Metadata},
 	btree::BTreeTable,
-	stats::ColumnStats,
+	compress::Compress,
 	db::check::CheckDisplay,
+	display::hex,
+	error::{Error, Result},
+	index::{Address, IndexTable, PlanOutcome, TableId as IndexTableId},
+	log::{Log, LogAction, LogOverlays, LogQuery, LogReader, LogWriter},
+	options::{ColumnOptions, Metadata, Options},
+	stats::ColumnStats,
+	table::{
+		key::{TableKey, TableKeyQuery},
+		TableId as ValueTableId, Value, ValueTable, SIZE_TIERS,
+	},
+	Key,
 };
-use crate::compress::Compress;
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use std::{
+	collections::VecDeque,
+	sync::atomic::{AtomicU64, Ordering},
+};
 
 const MIN_INDEX_BITS: u8 = 16;
 // Measured in index entries
@@ -59,9 +62,23 @@ pub type Salt = [u8; 32];
 //	r
 //};
 
-const SIZES: [u16; SIZE_TIERS - 1] = 
-	[32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 46, 47, 48, 50, 51, 52, 54, 55, 57, 58, 60, 62, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 88, 90, 93, 95, 98, 101, 103, 106, 109, 112, 115, 119, 122, 125, 129, 132, 136, 140, 144, 148, 152, 156, 160, 165, 169, 174, 179, 183, 189, 194, 199, 205, 210, 216, 222, 228, 235, 241, 248, 255, 262, 269, 276, 284, 292, 300, 308, 317, 325, 334, 344, 353, 363, 373, 383, 394, 405, 416, 428, 439, 452, 464, 477, 490, 504, 518, 532, 547, 562, 577, 593, 610, 627, 644, 662, 680, 699, 718, 738, 758, 779, 801, 823, 846, 869, 893, 918, 943, 969, 996, 1024, 1052, 1081, 1111, 1142, 1174, 1206, 1239, 1274, 1309, 1345, 1382, 1421, 1460, 1500, 1542, 1584, 1628, 1673, 1720, 1767, 1816, 1866, 1918, 1971, 2025, 2082, 2139, 2198, 2259, 2322, 2386, 2452, 2520, 2589, 2661, 2735, 2810, 2888, 2968, 3050, 3134, 3221, 3310, 3402, 3496, 3593, 3692, 3794, 3899, 4007, 4118, 4232, 4349, 4469, 4593, 4720, 4850, 4984, 5122, 5264, 5410, 5559, 5713, 5871, 6034, 6200, 6372, 6548, 6729, 6916, 7107, 7303, 7506, 7713, 7927, 8146, 8371, 8603, 8841, 9085, 9337, 9595, 9860, 10133, 10413, 10702, 10998, 11302, 11614, 11936, 12266, 12605, 12954, 13312, 13681, 14059, 14448, 14848, 15258, 15681, 16114, 16560, 17018, 17489, 17973, 18470, 18981, 19506, 20046, 20600, 21170, 21756, 22358, 22976, 23612, 24265, 24936, 25626, 26335, 27064, 27812, 28582, 29372, 30185, 31020, 31878, 32760]
-;
+const SIZES: [u16; SIZE_TIERS - 1] = [
+	32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 46, 47, 48, 50, 51, 52, 54, 55, 57, 58, 60,
+	62, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 88, 90, 93, 95, 98, 101, 103, 106, 109,
+	112, 115, 119, 122, 125, 129, 132, 136, 140, 144, 148, 152, 156, 160, 165, 169, 174, 179, 183,
+	189, 194, 199, 205, 210, 216, 222, 228, 235, 241, 248, 255, 262, 269, 276, 284, 292, 300, 308,
+	317, 325, 334, 344, 353, 363, 373, 383, 394, 405, 416, 428, 439, 452, 464, 477, 490, 504, 518,
+	532, 547, 562, 577, 593, 610, 627, 644, 662, 680, 699, 718, 738, 758, 779, 801, 823, 846, 869,
+	893, 918, 943, 969, 996, 1024, 1052, 1081, 1111, 1142, 1174, 1206, 1239, 1274, 1309, 1345,
+	1382, 1421, 1460, 1500, 1542, 1584, 1628, 1673, 1720, 1767, 1816, 1866, 1918, 1971, 2025, 2082,
+	2139, 2198, 2259, 2322, 2386, 2452, 2520, 2589, 2661, 2735, 2810, 2888, 2968, 3050, 3134, 3221,
+	3310, 3402, 3496, 3593, 3692, 3794, 3899, 4007, 4118, 4232, 4349, 4469, 4593, 4720, 4850, 4984,
+	5122, 5264, 5410, 5559, 5713, 5871, 6034, 6200, 6372, 6548, 6729, 6916, 7107, 7303, 7506, 7713,
+	7927, 8146, 8371, 8603, 8841, 9085, 9337, 9595, 9860, 10133, 10413, 10702, 10998, 11302, 11614,
+	11936, 12266, 12605, 12954, 13312, 13681, 14059, 14448, 14848, 15258, 15681, 16114, 16560,
+	17018, 17489, 17973, 18470, 18981, 19506, 20046, 20600, 21170, 21756, 22358, 22976, 23612,
+	24265, 24936, 25626, 26335, 27064, 27812, 28582, 29372, 30185, 31020, 31878, 32760,
+];
 
 struct Tables {
 	index: IndexTable,
@@ -123,7 +140,7 @@ pub fn hash_key(key: &[u8], salt: &Salt, uniform: bool, db_version: u32) -> Key 
 		} else {
 			// For keys that are hashes already we do a simple XOR with salt.
 			let key = &key[0..32];
-			for i in 0 .. 32 {
+			for i in 0..32 {
 				k[i] = key[i] ^ salt[i];
 			}
 		}
@@ -141,14 +158,14 @@ impl HashColumn {
 			if self.collect_stats {
 				self.stats.query_hit(tier);
 			}
-			return Ok(Some(value));
+			return Ok(Some(value))
 		}
 		for r in &self.reindex.read().queue {
 			if let Some((tier, value)) = self.get_in_index(key, r, values, log)? {
 				if self.collect_stats {
 					self.stats.query_hit(tier);
 				}
-				return Ok(Some(value));
+				return Ok(Some(value))
 			}
 		}
 		if self.collect_stats {
@@ -161,20 +178,31 @@ impl HashColumn {
 		self.get(key, log).map(|v| v.map(|v| v.len() as u32))
 	}
 
-	fn get_in_index(&self, key: &Key, index: &IndexTable, tables: TablesRef, log: &impl LogQuery) -> Result<Option<(u8, Value)>> {
+	fn get_in_index(
+		&self,
+		key: &Key,
+		index: &IndexTable,
+		tables: TablesRef,
+		log: &impl LogQuery,
+	) -> Result<Option<(u8, Value)>> {
 		let (mut entry, mut sub_index) = index.get(key, 0, log);
 		while !entry.is_empty() {
 			let address = entry.address(index.id.index_bits());
-			let value = Column::get_value(TableKeyQuery::Check(&TableKey::Partial(*key)), address, tables, log)?;
+			let value = Column::get_value(
+				TableKeyQuery::Check(&TableKey::Partial(*key)),
+				address,
+				tables,
+				log,
+			)?;
 			match value {
 				Some(result) => {
-					return Ok(Some(result));
-				}
+					return Ok(Some(result))
+				},
 				None => {
 					let (next_entry, next_index) = index.get(key, sub_index + 1, log);
 					entry = next_entry;
 					sub_index = next_index;
-				}
+				},
 			}
 		}
 		Ok(None)
@@ -192,20 +220,28 @@ impl HashColumn {
 }
 
 impl Column {
-	pub fn get_value(mut key: TableKeyQuery, address: Address, tables: TablesRef, log: &impl LogQuery) -> Result<Option<(u8, Value)>> {
+	pub fn get_value(
+		mut key: TableKeyQuery,
+		address: Address,
+		tables: TablesRef,
+		log: &impl LogQuery,
+	) -> Result<Option<(u8, Value)>> {
 		let size_tier = address.size_tier() as usize;
-		if let Some((value, compressed, _rc)) = tables.tables[size_tier].query(&mut key, address.offset(), log)? {
-			let value = if compressed {
-				tables.compression.decompress(&value)?
-			} else {
-				value
-			};
-			return Ok(Some((size_tier as u8, value)));
+		if let Some((value, compressed, _rc)) =
+			tables.tables[size_tier].query(&mut key, address.offset(), log)?
+		{
+			let value = if compressed { tables.compression.decompress(&value)? } else { value };
+			return Ok(Some((size_tier as u8, value)))
 		}
 		Ok(None)
 	}
 
-	pub fn compress(compression: &Compress, key: &TableKey, value: &[u8], tables: &[ValueTable]) -> (Option<Vec<u8>>, usize) {
+	pub fn compress(
+		compression: &Compress,
+		key: &TableKey,
+		value: &[u8],
+		tables: &[ValueTable],
+	) -> (Option<Vec<u8>>, usize) {
 		let (len, result) = if value.len() > compression.threshold as usize {
 			let cvalue = compression.compress(value);
 			if cvalue.len() < value.len() {
@@ -216,13 +252,15 @@ impl Column {
 		} else {
 			(value.len(), None)
 		};
-		let target_tier = tables.iter().position(|t| t.value_size(key).map_or(false, |s| len <= s as usize));
+		let target_tier = tables
+			.iter()
+			.position(|t| t.value_size(key).map_or(false, |s| len <= s as usize));
 		let target_tier = match target_tier {
 			Some(tier) => tier as usize,
 			None => {
 				log::trace!(target: "parity-db", "Using blob {}", key);
 				tables.len() - 1
-			}
+			},
 		};
 
 		(result, target_tier)
@@ -233,8 +271,9 @@ impl Column {
 		let arc_path = std::sync::Arc::new(path.clone());
 		let column_options = &metadata.columns[col as usize];
 		let db_version = metadata.version;
-		let value = (0 .. SIZE_TIERS)
-			.map(|i| Self::open_table(arc_path.clone(), col, i as u8, column_options, db_version)).collect::<Result<_>>()?;
+		let value = (0..SIZE_TIERS)
+			.map(|i| Self::open_table(arc_path.clone(), col, i as u8, column_options, db_version))
+			.collect::<Result<_>>()?;
 
 		if column_options.btree_index {
 			Ok(Column::Tree(BTreeTable::open(col, value, metadata)?))
@@ -257,7 +296,12 @@ impl Column {
 }
 
 impl HashColumn {
-	fn open(col: ColId, value: Vec<ValueTable>, options: &Options, metadata: &Metadata) -> Result<HashColumn> {
+	fn open(
+		col: ColId,
+		value: Vec<ValueTable>,
+		options: &Options,
+		metadata: &Metadata,
+	) -> Result<HashColumn> {
 		let (index, reindexing, stats) = Self::open_index(&options.path, col)?;
 		let collect_stats = options.stats;
 		let path = &options.path;
@@ -266,10 +310,7 @@ impl HashColumn {
 		Ok(HashColumn {
 			col,
 			tables: RwLock::new(Tables { index, value }),
-			reindex: RwLock::new(Reindex {
-				queue: reindexing,
-				progress: AtomicU64::new(0),
-			}),
+			reindex: RwLock::new(Reindex { queue: reindexing, progress: AtomicU64::new(0) }),
 			path: path.into(),
 			preimage: options.preimage,
 			uniform_keys: options.uniform,
@@ -295,11 +336,14 @@ impl HashColumn {
 		Ok(())
 	}
 
-	fn open_index(path: &std::path::Path, col: ColId) -> Result<(IndexTable, VecDeque<IndexTable>, ColumnStats)> {
+	fn open_index(
+		path: &std::path::Path,
+		col: ColId,
+	) -> Result<(IndexTable, VecDeque<IndexTable>, ColumnStats)> {
 		let mut reindexing = VecDeque::new();
 		let mut top = None;
 		let mut stats = ColumnStats::empty();
-		for bits in (MIN_INDEX_BITS .. 65).rev() {
+		for bits in (MIN_INDEX_BITS..65).rev() {
 			let id = IndexTableId::new(col, bits);
 			if let Some(table) = IndexTable::open_existing(path, id)? {
 				if top.is_none() {
@@ -330,10 +374,8 @@ impl HashColumn {
 			tables.index.id,
 		);
 		// Start reindex
-		let new_index_id = IndexTableId::new(
-			tables.index.id.col(),
-			tables.index.id.index_bits() + 1
-		);
+		let new_index_id =
+			IndexTableId::new(tables.index.id.col(), tables.index.id.index_bits() + 1);
 		let new_table = IndexTable::create_new(path, new_index_id);
 		let old_table = std::mem::replace(&mut tables.index, new_table);
 		reindex.queue.push_back(old_table);
@@ -343,11 +385,16 @@ impl HashColumn {
 		)
 	}
 
-	pub fn write_reindex_plan(&self, key: &Key, address: Address, log: &mut LogWriter) -> Result<PlanOutcome> {
+	pub fn write_reindex_plan(
+		&self,
+		key: &Key,
+		address: Address,
+		log: &mut LogWriter,
+	) -> Result<PlanOutcome> {
 		let tables = self.tables.upgradable_read();
 		let reindex = self.reindex.upgradable_read();
 		if Self::search_index(key, &tables.index, &*tables, log)?.is_some() {
-			return Ok(PlanOutcome::Skipped);
+			return Ok(PlanOutcome::Skipped)
 		}
 		match tables.index.write_insert_plan(key, address, None, log)? {
 			PlanOutcome::NeedReindex => {
@@ -355,10 +402,8 @@ impl HashColumn {
 				let _lock = Self::trigger_reindex(tables, reindex, self.path.as_path());
 				self.write_reindex_plan(key, address, log)?;
 				Ok(PlanOutcome::NeedReindex)
-			}
-			_ => {
-				Ok(PlanOutcome::Written)
-			}
+			},
+			_ => Ok(PlanOutcome::Written),
 		}
 	}
 
@@ -366,21 +411,25 @@ impl HashColumn {
 		key: &Key,
 		index: &'a IndexTable,
 		tables: &'a Tables,
-		log: &LogWriter
+		log: &LogWriter,
 	) -> Result<Option<(&'a IndexTable, usize, Address)>> {
 		let (mut existing_entry, mut sub_index) = index.get(key, 0, log);
 		while !existing_entry.is_empty() {
 			let existing_address = existing_entry.address(index.id.index_bits());
 			let existing_tier = existing_address.size_tier();
 			let table_key = TableKey::Partial(*key);
-			if tables.value[existing_tier as usize].has_key_at(existing_address.offset(), &table_key, log)? {
-				return Ok(Some((index, sub_index, existing_address)));
+			if tables.value[existing_tier as usize].has_key_at(
+				existing_address.offset(),
+				&table_key,
+				log,
+			)? {
+				return Ok(Some((index, sub_index, existing_address)))
 			}
 
 			let (next_entry, next_index) = index.get(key, sub_index + 1, log);
 			existing_entry = next_entry;
 			sub_index = next_index;
-		};
+		}
 		Ok(None)
 	}
 
@@ -388,19 +437,19 @@ impl HashColumn {
 		key: &Key,
 		tables: &'a Tables,
 		reindex: &'a Reindex,
-		log: &LogWriter
+		log: &LogWriter,
 	) -> Result<Option<(&'a IndexTable, usize, Address)>> {
-			if let Some(r) = Self::search_index(key, &tables.index, tables, log)? {
-				return Ok(Some(r));
+		if let Some(r) = Self::search_index(key, &tables.index, tables, log)? {
+			return Ok(Some(r))
+		}
+		// Check old indexes
+		// TODO: don't search if index precedes reindex progress
+		for index in &reindex.queue {
+			if let Some(r) = Self::search_index(key, index, tables, log)? {
+				return Ok(Some(r))
 			}
-			// Check old indexes
-			// TODO: don't search if index precedes reindex progress
-			for index in &reindex.queue {
-				if let Some(r) = Self::search_index(key, index, tables, log)? {
-					return Ok(Some(r));
-				}
-			}
-			Ok(None)
+		}
+		Ok(None)
 	}
 
 	pub fn write_plan(
@@ -415,15 +464,15 @@ impl HashColumn {
 		if let Some((table, sub_index, existing_address)) = existing {
 			self.write_plan_existing(&*tables, key, value, log, table, sub_index, existing_address)
 		} else if let Some(value) = value {
-            let (r, _, _) = self.write_plan_new(tables, reindex, key, value, log)?;
-            Ok(r)
-        } else {
-            log::trace!(target: "parity-db", "{}: Deleting missing key {}", tables.index.id, hex(key));
-            if self.collect_stats {
-                self.stats.remove_miss();
-            }
-            Ok(PlanOutcome::Skipped)
-        }
+			let (r, _, _) = self.write_plan_new(tables, reindex, key, value, log)?;
+			Ok(r)
+		} else {
+			log::trace!(target: "parity-db", "{}: Deleting missing key {}", tables.index.id, hex(key));
+			if self.collect_stats {
+				self.stats.remove_miss();
+			}
+			Ok(PlanOutcome::Skipped)
+		}
 	}
 
 	fn write_plan_existing(
@@ -436,11 +485,7 @@ impl HashColumn {
 		sub_index: usize,
 		existing_address: Address,
 	) -> Result<PlanOutcome> {
-		let stats = if self.collect_stats {
-			Some(&self.stats)
-		} else {
-			None
-		};
+		let stats = if self.collect_stats { Some(&self.stats) } else { None };
 
 		let table_key = TableKey::Partial(*key);
 		match Column::write_existing_value_plan(
@@ -452,14 +497,17 @@ impl HashColumn {
 			stats,
 		)? {
 			(Some(outcome), _) => return Ok(outcome),
-			(None, Some(value_address)) => if value.is_some() {
-				// If it was found in an older index we just insert a new entry. Reindex won't overwrite it.
-				let sub_index = if index.id == tables.index.id { Some(sub_index) } else { None };
-				return tables.index.write_insert_plan(key, value_address, sub_index, log);
-			} else {
-				log::trace!(target: "parity-db", "{}: Removing from index {}", tables.index.id, hex(key));
-				index.write_remove_plan(key, sub_index, log)?;
-			},
+			(None, Some(value_address)) =>
+				if value.is_some() {
+					// If it was found in an older index we just insert a new entry. Reindex won't
+					// overwrite it.
+					let sub_index =
+						if index.id == tables.index.id { Some(sub_index) } else { None };
+					return tables.index.write_insert_plan(key, value_address, sub_index, log)
+				} else {
+					log::trace!(target: "parity-db", "{}: Removing from index {}", tables.index.id, hex(key));
+					index.write_remove_plan(key, sub_index, log)?;
+				},
 			_ => unreachable!(),
 		}
 		Ok(PlanOutcome::Skipped)
@@ -472,17 +520,27 @@ impl HashColumn {
 		key: &Key,
 		value: &[u8],
 		log: &mut LogWriter,
-	) -> Result<(PlanOutcome, RwLockUpgradableReadGuard<'a, Tables>, RwLockUpgradableReadGuard<'b, Reindex>)> {
+	) -> Result<(
+		PlanOutcome,
+		RwLockUpgradableReadGuard<'a, Tables>,
+		RwLockUpgradableReadGuard<'b, Reindex>,
+	)> {
 		let stats = self.collect_stats.then(|| &self.stats);
 		let table_key = TableKey::Partial(*key);
-		let address = Column::write_new_value_plan(&table_key, self.as_ref(&tables.value), value, log, stats)?;
+		let address = Column::write_new_value_plan(
+			&table_key,
+			self.as_ref(&tables.value),
+			value,
+			log,
+			stats,
+		)?;
 		match tables.index.write_insert_plan(key, address, None, log)? {
 			PlanOutcome::NeedReindex => {
 				log::debug!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));
 				let (tables, reindex) = Self::trigger_reindex(tables, reindex, self.path.as_path());
 				let (_, t, r) = self.write_plan_new(tables, reindex, key, value, log)?;
 				Ok((PlanOutcome::NeedReindex, t, r))
-			}
+			},
 			_ => Ok((PlanOutcome::Written, tables, reindex)),
 		}
 	}
@@ -494,7 +552,7 @@ impl HashColumn {
 			LogAction::InsertIndex(record) => {
 				if tables.index.id == record.table {
 					tables.index.enact_plan(record.index, log)?;
-				} else if let Some(table) = reindex.queue.iter().find(|r|r.id == record.table) {
+				} else if let Some(table) = reindex.queue.iter().find(|r| r.id == record.table) {
 					table.enact_plan(record.index, log)?;
 				} else {
 					// This may happen when removal is planed for an old index when reindexing.
@@ -512,7 +570,8 @@ impl HashColumn {
 				tables.value[record.table.size_tier() as usize].enact_plan(record.index, log)?;
 			},
 			// This should never happen, unless something has modified the log file while the
-			// database is running. Existing logs should be validated with `validate_plan` on startup.
+			// database is running. Existing logs should be validated with `validate_plan` on
+			// startup.
 			_ => return Err(Error::Corruption("Unexpected log action".into())),
 		}
 		Ok(())
@@ -525,7 +584,7 @@ impl HashColumn {
 			LogAction::InsertIndex(record) => {
 				if tables.index.id == record.table {
 					tables.index.validate_plan(record.index, log)?;
-				} else if let Some(table) = reindex.queue.iter().find(|r|r.id == record.table) {
+				} else if let Some(table) = reindex.queue.iter().find(|r| r.id == record.table) {
 					table.validate_plan(record.index, log)?;
 				} else {
 					// Re-launch previously started reindex
@@ -536,7 +595,7 @@ impl HashColumn {
 						record.table,
 					);
 					let _lock = Self::trigger_reindex(tables, reindex, self.path.as_path());
-					return self.validate_plan(LogAction::InsertIndex(record), log);
+					return self.validate_plan(LogAction::InsertIndex(record), log)
 				}
 			},
 			LogAction::InsertValue(record) => {
@@ -544,7 +603,7 @@ impl HashColumn {
 			},
 			_ => {
 				log::error!(target: "parity-db", "Unexpected log action");
-				return Err(Error::Corruption("Unexpected log action".to_string()));
+				return Err(Error::Corruption("Unexpected log action".to_string()))
 			},
 		}
 		Ok(())
@@ -582,9 +641,10 @@ impl HashColumn {
 	}
 
 	pub fn iter_while(&self, log: &Log, mut f: impl FnMut(IterState) -> bool) -> Result<()> {
-		let action = |state | match state {
+		let action = |state| match state {
 			IterStateOrCorrupted::Item(item) => Ok(f(item)),
-			IterStateOrCorrupted::Corrupted( .. ) => Err(Error::Corruption("Missing indexed value".into())),
+			IterStateOrCorrupted::Corrupted(..) =>
+				Err(Error::Corruption("Missing indexed value".into())),
 		};
 		self.iter_while_inner(log, action, 0, true)
 	}
@@ -609,25 +669,30 @@ impl HashColumn {
 						if let Ok(value) = self.compression.decompress(&value) {
 							value
 						} else {
-							return false;
+							return false
 						}
 					} else {
 						value
 					};
 					let key = blake2_rfc::blake2b::blake2b(32, &[], &value);
 					let key = self.hash_key(key.as_bytes());
-					let state = IterStateOrCorrupted::Item(IterState { chunk_index: index, key, rc, value });
+					let state = IterStateOrCorrupted::Item(IterState {
+						chunk_index: index,
+						key,
+						rc,
+						value,
+					});
 					f(state).unwrap_or(false)
 				})?;
 				log::debug!( target: "parity-db", "{}: Done Iterating table {}", source.id, table.id);
 			}
 		}
 
-		for c in start_chunk .. source.id.total_chunks() {
+		for c in start_chunk..source.id.total_chunks() {
 			let entries = source.entries(c, &*log.overlays());
 			for entry in entries.iter() {
 				if entry.is_empty() {
-					continue;
+					continue
 				}
 				let (size_tier, offset) = if self.db_version >= 4 {
 					let address = entry.address(source.id.index_bits());
@@ -640,28 +705,27 @@ impl HashColumn {
 					(size_tier, offset)
 				};
 
-				if skip_preimage_indexes && self.preimage && size_tier as usize != tables.value.len() - 1 {
-					continue;
+				if skip_preimage_indexes &&
+					self.preimage && size_tier as usize != tables.value.len() - 1
+				{
+					continue
 				}
-				let value = tables.value[size_tier as usize].get_with_meta(offset, &*log.overlays());
+				let value =
+					tables.value[size_tier as usize].get_with_meta(offset, &*log.overlays());
 				let (value, rc, pk, compressed) = match value {
 					Ok(Some(v)) => v,
 					Ok(None) => {
 						f(IterStateOrCorrupted::Corrupted(*entry, None))?;
-						continue;
+						continue
 					},
 					Err(e) => {
 						f(IterStateOrCorrupted::Corrupted(*entry, Some(e)))?;
-						continue;
+						continue
 					},
 				};
 				let mut key = source.recover_key_prefix(c, *entry);
 				key[6..].copy_from_slice(&pk);
-				let value = if compressed {
-					self.compression.decompress(&value)?
-				} else {
-					value
-				};
+				let value = if compressed { self.compression.decompress(&value)? } else { value };
 				log::debug!(
 					target: "parity-db",
 					"{}: Iterating at {}/{}, key={:?}, pk={:?}",
@@ -671,7 +735,8 @@ impl HashColumn {
 					hex(&key),
 					hex(&pk),
 				);
-				let state = IterStateOrCorrupted::Item(IterState { chunk_index: c, key, rc, value });
+				let state =
+					IterStateOrCorrupted::Item(IterState { chunk_index: c, key, rc, value });
 				if !f(state)? {
 					return Ok(())
 				}
@@ -688,38 +753,47 @@ impl HashColumn {
 		let start_time = std::time::Instant::now();
 		log::info!(target: "parity-db", "Starting full index iteration at {:?}", start_time);
 		log::info!(target: "parity-db", "for {} chunks of column {}", self.tables.read().index.id.total_chunks(), col);
-		self.iter_while_inner(log, |state| match state {
-			IterStateOrCorrupted::Item(IterState { chunk_index, key, rc, value }) => {
-				if Some(chunk_index) == end_chunk {
-					return Ok(false);
-				}
-				if chunk_index % step == 0 {
-					log::info!(target: "parity-db", "Chunk iteration at {}", chunk_index);
-				}
+		self.iter_while_inner(
+			log,
+			|state| match state {
+				IterStateOrCorrupted::Item(IterState { chunk_index, key, rc, value }) => {
+					if Some(chunk_index) == end_chunk {
+						return Ok(false)
+					}
+					if chunk_index % step == 0 {
+						log::info!(target: "parity-db", "Chunk iteration at {}", chunk_index);
+					}
 
-				match check_param.display {
-					CheckDisplay::Full => {
-						log::info!("Index key: {:x?}\n \
+					match check_param.display {
+						CheckDisplay::Full => {
+							log::info!(
+								"Index key: {:x?}\n \
 							\tRc: {}",
-							&key,
-							rc,
-						);
-						log::info!("Value: {}", hex(&value));
-					},
-					CheckDisplay::Short(t) => {
-						log::info!("Index key: {:x?}", &key);
-						log::info!("Rc: {}, Value len: {}", rc, value.len());
-						log::info!("Value: {}", hex(&value[..std::cmp::min(t as usize, value.len())]));
-					},
-					CheckDisplay::None => (),
-				}
-				Ok(true)
+								&key,
+								rc,
+							);
+							log::info!("Value: {}", hex(&value));
+						},
+						CheckDisplay::Short(t) => {
+							log::info!("Index key: {:x?}", &key);
+							log::info!("Rc: {}, Value len: {}", rc, value.len());
+							log::info!(
+								"Value: {}",
+								hex(&value[..std::cmp::min(t as usize, value.len())])
+							);
+						},
+						CheckDisplay::None => (),
+					}
+					Ok(true)
+				},
+				IterStateOrCorrupted::Corrupted(entry, e) => {
+					log::info!("Corrupted value for index entry: {}:\n\t{:?}", entry.as_u64(), e);
+					Ok(true)
+				},
 			},
-			IterStateOrCorrupted::Corrupted(entry, e) => {
-				log::info!("Corrupted value for index entry: {}:\n\t{:?}", entry.as_u64(), e);
-				Ok(true)
-			},
-		}, start_chunk, false)?;
+			start_chunk,
+			false,
+		)?;
 
 		log::info!(target: "parity-db", "Ended full index check, elapsed {:?}", start_time.elapsed());
 		Ok(())
@@ -744,7 +818,7 @@ impl HashColumn {
 					let entries = source.entries(source_index, &*log.overlays());
 					for entry in entries.iter() {
 						if entry.is_empty() {
-							continue;
+							continue
 						}
 						// We only need key prefix to reindex.
 						let key = source.recover_key_prefix(source_index, *entry);
@@ -772,7 +846,7 @@ impl HashColumn {
 			table.unwrap().drop_file()?;
 		} else {
 			log::warn!(target: "parity-db", "Dropping invalid index {}", id);
-			return Ok(());
+			return Ok(())
 		}
 		log::debug!(target: "parity-db", "Dropped {}", id);
 		Ok(())
@@ -793,52 +867,67 @@ impl Column {
 			if tables.ref_counted {
 				log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 				tables.tables[tier].write_inc_ref(address.offset(), log)?;
-				return Ok((Some(PlanOutcome::Written), None));
+				return Ok((Some(PlanOutcome::Written), None))
 			}
 			if tables.preimage {
 				// Replace is not supported
-				return Ok((Some(PlanOutcome::Skipped), None));
+				return Ok((Some(PlanOutcome::Skipped), None))
 			}
 
 			let (cval, target_tier) = Column::compress(tables.compression, key, val, tables.tables);
-			let (cval, compressed) = cval.as_ref()
-				.map(|cval| (cval.as_slice(), true))
-				.unwrap_or((val, false));
+			let (cval, compressed) =
+				cval.as_ref().map(|cval| (cval.as_slice(), true)).unwrap_or((val, false));
 
 			if let Some(stats) = stats {
-				let (cur_size, compressed) = tables.tables[tier].size(key, address.offset(), log)?
-					.unwrap_or((0, false));
+				let (cur_size, compressed) =
+					tables.tables[tier].size(key, address.offset(), log)?.unwrap_or((0, false));
 				if compressed {
 					// This is very costly.
-					let compressed = tables.tables[tier].get(key, address.offset(), log)?
-						.expect("Same query as size").0;
+					let compressed = tables.tables[tier]
+						.get(key, address.offset(), log)?
+						.expect("Same query as size")
+						.0;
 					let uncompressed = tables.compression.decompress(compressed.as_slice())?;
 
-					stats.replace_val(cur_size, uncompressed.len() as u32, val.len() as u32, cval.len() as u32);
+					stats.replace_val(
+						cur_size,
+						uncompressed.len() as u32,
+						val.len() as u32,
+						cval.len() as u32,
+					);
 				} else {
 					stats.replace_val(cur_size, cur_size, val.len() as u32, cval.len() as u32);
 				}
 			}
 			if tier == target_tier {
 				log::trace!(target: "parity-db", "{}: Replacing {}", tables.col, key);
-				tables.tables[target_tier].write_replace_plan(address.offset(), key, cval, log, compressed)?;
+				tables.tables[target_tier].write_replace_plan(
+					address.offset(),
+					key,
+					cval,
+					log,
+					compressed,
+				)?;
 				Ok((Some(PlanOutcome::Written), None))
 			} else {
 				log::trace!(target: "parity-db", "{}: Replacing in a new table {}", tables.col, key);
 				tables.tables[tier].write_remove_plan(address.offset(), log)?;
-				let new_offset = tables.tables[target_tier].write_insert_plan(key, cval, log, compressed)?;
+				let new_offset =
+					tables.tables[target_tier].write_insert_plan(key, cval, log, compressed)?;
 				let new_address = Address::new(new_offset, target_tier as u8);
 				Ok((None, Some(new_address)))
 			}
 		} else {
 			// Deletion
 			let cur_size = if stats.is_some() {
-				let (cur_size, compressed) = tables.tables[tier].size(key, address.offset(), log)?
-					.unwrap_or((0, false));
+				let (cur_size, compressed) =
+					tables.tables[tier].size(key, address.offset(), log)?.unwrap_or((0, false));
 				Some(if compressed {
 					// This is very costly.
-					let compressed = tables.tables[tier].get(key, address.offset(), log)?
-						.expect("Same query as size").0;
+					let compressed = tables.tables[tier]
+						.get(key, address.offset(), log)?
+						.expect("Same query as size")
+						.0;
 					let uncompressed = tables.compression.decompress(compressed.as_slice())?;
 
 					(cur_size, uncompressed.len() as u32)
@@ -878,9 +967,8 @@ impl Column {
 		stats: Option<&ColumnStats>,
 	) -> Result<Address> {
 		let (cval, target_tier) = Column::compress(tables.compression, key, val, tables.tables);
-		let (cval, compressed) = cval.as_ref()
-			.map(|cval| (cval.as_slice(), true))
-			.unwrap_or((val, false));
+		let (cval, compressed) =
+			cval.as_ref().map(|cval| (cval.as_slice(), true)).unwrap_or((val, false));
 
 		log::trace!(target: "parity-db", "{}: Inserting new {}, size = {}", tables.col, key, cval.len());
 		let offset = tables.tables[target_tier].write_insert_plan(key, cval, log, compressed)?;

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-
 //! Compression utility and types.
 
 use crate::error::Result;
@@ -37,17 +36,12 @@ pub struct Compress {
 
 impl Compress {
 	pub fn new(kind: CompressionType, threshold: u32) -> Self {
-		Compress {
-			inner: kind.into(),
-			threshold,
-		}
+		Compress { inner: kind.into(), threshold }
 	}
 }
 
-pub const NO_COMPRESSION: Compress = Compress {
-	inner: Compressor::NoCompression(NoCompression),
-	threshold: u32::MAX,
-};
+pub const NO_COMPRESSION: Compress =
+	Compress { inner: Compressor::NoCompression(NoCompression), threshold: u32::MAX };
 
 enum Compressor {
 	NoCompression(NoCompression),
@@ -135,8 +129,7 @@ mod lz4 {
 		}
 
 		pub(super) fn compress(&self, buf: &[u8]) -> Vec<u8> {
-			lz4::block::compress(buf, Some(lz4::block::CompressionMode::DEFAULT), true)
-				.unwrap()
+			lz4::block::compress(buf, Some(lz4::block::CompressionMode::DEFAULT), true).unwrap()
 		}
 
 		pub(super) fn decompress(&self, buf: &[u8]) -> Result<Vec<u8>> {
@@ -180,18 +173,15 @@ mod tests {
 
 	#[test]
 	fn test_compression_interfaces() {
-		let original = vec![42;100];
-		let types = vec![
-			CompressionType::NoCompression,
-			CompressionType::Snappy,
-			CompressionType::Lz4
-		];
+		let original = vec![42; 100];
+		let types =
+			vec![CompressionType::NoCompression, CompressionType::Snappy, CompressionType::Lz4];
 
 		for compression_type in types {
 			let compress = Compress::new(compression_type, 0);
 			let v = compress.compress(&original[..]);
 			assert!(v.len() <= 100);
-			let round_tripped = compress.decompress( &v[..]).unwrap();
+			let round_tripped = compress.decompress(&v[..]).unwrap();
 			assert_eq!(original, round_tripped);
 		}
 	}

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -160,7 +160,7 @@ mod snappy {
 			let mut buf = Vec::with_capacity(value.len() << 3);
 			{
 				let mut encoder = snap::write::FrameEncoder::new(&mut buf);
-				encoder.write(value).expect("Expect in memory write to succeed.");
+				encoder.write_all(value).expect("Expect in memory write to succeed.");
 			}
 			buf
 		}

--- a/src/db.rs
+++ b/src/db.rs
@@ -446,8 +446,8 @@ impl DbInner {
 				);
 				for (key, address) in batch.into_iter() {
 					if let PlanOutcome::NeedReindex = column.write_reindex_plan(&key, address, &mut writer)? {
-     					next_reindex = true
-     				}
+						next_reindex = true
+					}
 				}
 				if let Some(table) = drop_index {
 					writer.drop_table(table);
@@ -1087,8 +1087,9 @@ impl IndexedChangeSet {
 		};
 		for (key, value) in self.changes.iter() {
 			if let PlanOutcome::NeedReindex = column.write_plan(key, value.as_ref().map(|v| v.as_slice()), writer)? {
-   					*reindex = true;
-   				}
+					// Reindex has triggered another reindex.
+					*reindex = true;
+				}
 			*ops += 1;
 		}
 		Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -14,6 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::{
+	btree::{commit_overlay::BTreeChangeSet, BTreeIterator, BTreeTable},
+	column::{hash_key, ColId, Column, IterState},
+	error::{Error, Result},
+	index::PlanOutcome,
+	log::{Log, LogAction},
+	options::Options,
+	Key,
+};
+use fs2::FileExt;
+use parking_lot::{Condvar, Mutex, RwLock};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 /// The database objects is split into `Db` and `DbInner`.
 /// `Db` creates shared `DbInner` instance and manages background
 /// worker threads that all use the inner object.
@@ -30,19 +42,9 @@
 /// cleanup_worker: Flush tables by calling `fsync`, and cleanup log.
 /// Each background worker is signalled with a conditional variable once
 /// there is some work to be done.
-
-use std::sync::{Arc, atomic::{AtomicBool, AtomicU64, Ordering}};
-use std::collections::{HashMap, VecDeque, BTreeMap};
-use parking_lot::{RwLock, Mutex, Condvar};
-use fs2::FileExt;
-use crate::{
-	Key,
-	error::{Error, Result},
-	column::{ColId, Column, IterState, hash_key},
-	log::{Log, LogAction},
-	index::PlanOutcome,
-	options::Options,
-	btree::{BTreeIterator, BTreeTable, commit_overlay::{BTreeChangeSet}},
+use std::sync::{
+	atomic::{AtomicBool, AtomicU64, Ordering},
+	Arc,
 };
 
 // Max size of commit queue. (Keys + Values). If the queue is
@@ -95,7 +97,8 @@ struct DbInner {
 	commit_worker_wait: Arc<WaitCondvar<bool>>,
 	// Overlay of most recent values in the commit queue.
 	commit_overlay: RwLock<Vec<CommitOverlay>>,
-	log_queue_wait: WaitCondvar<i64>, // This may underflow occasionally, but is bound for 0 eventually
+	log_queue_wait: WaitCondvar<i64>, /* This may underflow occasionally, but is bound for 0
+	                                   * eventually */
 	flush_worker_wait: Arc<WaitCondvar<bool>>,
 	cleanup_worker_wait: WaitCondvar<bool>,
 	last_enacted: AtomicU64,
@@ -112,10 +115,7 @@ struct WaitCondvar<S> {
 
 impl<S: Default> WaitCondvar<S> {
 	fn new() -> Self {
-		WaitCondvar {
-			cv: Condvar::new(),
-			work: Mutex::new(S::default()),
-		}
+		WaitCondvar { cv: Condvar::new(), work: Mutex::new(S::default()) }
 	}
 }
 
@@ -130,7 +130,7 @@ impl WaitCondvar<bool> {
 		let mut work = self.work.lock();
 		while !*work {
 			self.cv.wait(&mut work)
-		};
+		}
 		*work = false;
 	}
 }
@@ -142,7 +142,11 @@ impl DbInner {
 		};
 		let mut lock_path: std::path::PathBuf = options.path.clone();
 		lock_path.push("lock");
-		let lock_file = std::fs::OpenOptions::new().create(true).read(true).write(true).open(lock_path.as_path())?;
+		let lock_file = std::fs::OpenOptions::new()
+			.create(true)
+			.read(true)
+			.write(true)
+			.open(lock_path.as_path())?;
 		if !inner_options.skip_check_lock {
 			lock_file.try_lock_exclusive().map_err(Error::Locked)?;
 		}
@@ -152,7 +156,7 @@ impl DbInner {
 		let mut commit_overlay = Vec::with_capacity(metadata.columns.len());
 		let log = Log::open(options)?;
 		let last_enacted = log.replay_record_id().unwrap_or(2) - 1;
-		for c in 0 .. metadata.columns.len() {
+		for c in 0..metadata.columns.len() {
 			let column = Column::open(c as ColId, options, &metadata)?;
 			commit_overlay.push(CommitOverlay::new());
 			columns.push(column);
@@ -191,7 +195,7 @@ impl DbInner {
 				let overlay = self.commit_overlay.read();
 				// Check commit overlay first
 				if let Some(v) = overlay.get(col as usize).and_then(|o| o.get(&key)) {
-					return Ok(v);
+					return Ok(v)
 				}
 				// Go into tables and log overlay.
 				let log = self.log.overlays();
@@ -200,7 +204,7 @@ impl DbInner {
 			Column::Tree(column) => {
 				let overlay = self.commit_overlay.read();
 				if let Some(l) = overlay.get(col as usize).and_then(|o| o.btree_get(key)) {
-					return Ok(l.cloned());
+					return Ok(l.cloned())
 				}
 				// We lock log, if btree structure changed while reading that would be an issue.
 				let log = self.log.overlays().read();
@@ -216,7 +220,7 @@ impl DbInner {
 				let overlay = self.commit_overlay.read();
 				// Check commit overlay first
 				if let Some(l) = overlay.get(col as usize).and_then(|o| o.get_size(&key)) {
-					return Ok(l);
+					return Ok(l)
 				}
 				// Go into tables and log overlay.
 				let log = self.log.overlays();
@@ -225,7 +229,7 @@ impl DbInner {
 			Column::Tree(column) => {
 				let overlay = self.commit_overlay.read();
 				if let Some(l) = overlay.get(col as usize).and_then(|o| o.btree_get(key)) {
-					return Ok(l.map(|v| v.len() as u32));
+					return Ok(l.map(|v| v.len() as u32))
 				}
 				let log = self.log.overlays().read();
 				let l = column.with_locked(|btree| BTreeTable::get(key, &*log, btree))?;
@@ -236,9 +240,8 @@ impl DbInner {
 
 	pub fn btree_iter(&self, col: ColId) -> Result<BTreeIterator> {
 		match &self.columns[col as usize] {
-			Column::Hash(_column) => {
-				Err(Error::InvalidConfiguration("Not an indexed column.".to_string()))
-			},
+			Column::Hash(_column) =>
+				Err(Error::InvalidConfiguration("Not an indexed column.".to_string())),
 			Column::Tree(column) => {
 				let log = self.log.overlays();
 				BTreeIterator::new(column, col, log, &self.commit_overlay)
@@ -250,19 +253,24 @@ impl DbInner {
 	// exits as early as possible.
 	fn commit<I, K>(&self, tx: I) -> Result<()>
 	where
-		I: IntoIterator<Item=(ColId, K, Option<Value>)>,
+		I: IntoIterator<Item = (ColId, K, Option<Value>)>,
 		K: AsRef<[u8]>,
 	{
 		let mut commit: CommitChangeSet = Default::default();
 		for (c, k, v) in tx.into_iter() {
 			if self.options.columns[c as usize].btree_index {
-				commit.btree_indexed.entry(c)
+				commit
+					.btree_indexed
+					.entry(c)
 					.or_insert_with(|| BTreeChangeSet::new(c))
 					.push(k.as_ref(), v)
 			} else {
-				commit.indexed.entry(c)
-					.or_insert_with(|| IndexedChangeSet::new(c))
-					.push(k.as_ref(), v, &self.options, self.db_version)
+				commit.indexed.entry(c).or_insert_with(|| IndexedChangeSet::new(c)).push(
+					k.as_ref(),
+					v,
+					&self.options,
+					self.db_version,
+				)
 			}
 		}
 
@@ -279,7 +287,7 @@ impl DbInner {
 			{
 				let bg_err = self.bg_err.lock();
 				if let Some(err) = &*bg_err {
-					return Err(Error::Background(err.clone()));
+					return Err(Error::Background(err.clone()))
 				}
 			}
 
@@ -290,18 +298,24 @@ impl DbInner {
 
 			let mut bytes = 0;
 			for (c, indexed) in &commit.indexed {
-				indexed.copy_to_overlay(&mut overlay[*c as usize], record_id, &mut bytes, &self.options);
+				indexed.copy_to_overlay(
+					&mut overlay[*c as usize],
+					record_id,
+					&mut bytes,
+					&self.options,
+				);
 			}
 
 			for (c, iterset) in &commit.btree_indexed {
-				iterset.copy_to_overlay(&mut overlay[*c as usize].btree_indexed, record_id, &mut bytes, &self.options);
+				iterset.copy_to_overlay(
+					&mut overlay[*c as usize].btree_indexed,
+					record_id,
+					&mut bytes,
+					&self.options,
+				);
 			}
 
-			let commit = Commit {
-				id: record_id,
-				changeset: commit,
-				bytes,
-			};
+			let commit = Commit { id: record_id, changeset: commit, bytes };
 
 			log::debug!(
 				target: "parity-db",
@@ -335,7 +349,9 @@ impl DbInner {
 					commit.bytes,
 					queue.bytes,
 				);
-				if queue.bytes <= MAX_COMMIT_QUEUE_BYTES && (queue.bytes + commit.bytes) > MAX_COMMIT_QUEUE_BYTES {
+				if queue.bytes <= MAX_COMMIT_QUEUE_BYTES &&
+					(queue.bytes + commit.bytes) > MAX_COMMIT_QUEUE_BYTES
+				{
 					// Past the waiting threshold.
 					log::debug!(
 						target: "parity-db",
@@ -361,13 +377,20 @@ impl DbInner {
 			);
 			let mut ops: u64 = 0;
 			for (c, key_values) in commit.changeset.indexed.iter() {
-				key_values.write_plan(&self.columns[*c as usize], &mut writer, &mut ops, &mut reindex)?;
+				key_values.write_plan(
+					&self.columns[*c as usize],
+					&mut writer,
+					&mut ops,
+					&mut reindex,
+				)?;
 			}
 
 			for (c, btree) in commit.changeset.btree_indexed.iter_mut() {
 				match &self.columns[*c as usize] {
 					Column::Hash(_column) => {
-						return Err(Error::InvalidConfiguration("Not an indexed column.".to_string()));
+						return Err(Error::InvalidConfiguration(
+							"Not an indexed column.".to_string(),
+						))
 					},
 					Column::Tree(column) => {
 						btree.write_plan(column, &mut writer, &mut ops)?;
@@ -433,7 +456,7 @@ impl DbInner {
 			let column = if let Column::Hash(c) = column {
 				c
 			} else {
-				continue;
+				continue
 			};
 			let (drop_index, batch) = column.reindex(&self.log)?;
 			if !batch.is_empty() || drop_index.is_some() {
@@ -445,7 +468,9 @@ impl DbInner {
 					writer.record_id(),
 				);
 				for (key, address) in batch.into_iter() {
-					if let PlanOutcome::NeedReindex = column.write_reindex_plan(&key, address, &mut writer)? {
+					if let PlanOutcome::NeedReindex =
+						column.write_reindex_plan(&key, address, &mut writer)?
+					{
 						next_reindex = true
 					}
 				}
@@ -482,8 +507,8 @@ impl DbInner {
 				Err(Error::Corruption(_)) if validation_mode => {
 					log::debug!(target: "parity-db", "Bad log header");
 					self.log.clear_replay_logs()?;
-					return Ok(false);
-				}
+					return Ok(false)
+				},
 				Err(e) => return Err(e),
 			};
 			if let Some(mut reader) = reader {
@@ -502,7 +527,7 @@ impl DbInner {
 						);
 						std::mem::drop(reader);
 						self.log.clear_replay_logs()?;
-						return Ok(false);
+						return Ok(false)
 					}
 					// Validate all records before applying anything
 					loop {
@@ -512,40 +537,44 @@ impl DbInner {
 								log::debug!(target: "parity-db", "Error reading log: {:?}", e);
 								std::mem::drop(reader);
 								self.log.clear_replay_logs()?;
-								return Ok(false);
-							}
+								return Ok(false)
+							},
 						};
 						match next {
 							LogAction::BeginRecord => {
 								log::debug!(target: "parity-db", "Unexpected log header");
 								std::mem::drop(reader);
 								self.log.clear_replay_logs()?;
-								return Ok(false);
+								return Ok(false)
 							},
 							LogAction::EndRecord => {
-								break;
+								break
 							},
 							LogAction::InsertIndex(insertion) => {
 								let col = insertion.table.col() as usize;
-								if let Err(e) = self.columns[col].validate_plan(LogAction::InsertIndex(insertion), &mut reader) {
+								if let Err(e) = self.columns[col]
+									.validate_plan(LogAction::InsertIndex(insertion), &mut reader)
+								{
 									log::warn!(target: "parity-db", "Error replaying log: {:?}. Reverting", e);
 									std::mem::drop(reader);
 									self.log.clear_replay_logs()?;
-									return Ok(false);
+									return Ok(false)
 								}
 							},
 							LogAction::InsertValue(insertion) => {
 								let col = insertion.table.col() as usize;
-								if let Err(e) = self.columns[col].validate_plan(LogAction::InsertValue(insertion), &mut reader) {
+								if let Err(e) = self.columns[col]
+									.validate_plan(LogAction::InsertValue(insertion), &mut reader)
+								{
 									log::warn!(target: "parity-db", "Error replaying log: {:?}. Reverting", e);
 									std::mem::drop(reader);
 									self.log.clear_replay_logs()?;
-									return Ok(false);
+									return Ok(false)
 								}
 							},
 							LogAction::DropTable(_) => {
-								continue;
-							}
+								continue
+							},
 						}
 					}
 					reader.reset()?;
@@ -554,15 +583,14 @@ impl DbInner {
 				loop {
 					match reader.next()? {
 						LogAction::BeginRecord => {
-							return Err(Error::Corruption("Bad log record".into()));
+							return Err(Error::Corruption("Bad log record".into()))
 						},
 						LogAction::EndRecord => {
-							break;
+							break
 						},
 						LogAction::InsertIndex(insertion) => {
 							self.columns[insertion.table.col() as usize]
 								.enact_plan(LogAction::InsertIndex(insertion), &mut reader)?;
-
 						},
 						LogAction::InsertValue(insertion) => {
 							self.columns[insertion.table.col() as usize]
@@ -582,7 +610,7 @@ impl DbInner {
 								},
 								Column::Tree(_) => (),
 							}
-						}
+						},
 					}
 				}
 				log::debug!(
@@ -618,7 +646,9 @@ impl DbInner {
 						);
 					}
 					*queue -= bytes as i64;
-					if *queue <= MAX_LOG_QUEUE_BYTES && (*queue + bytes as i64) > MAX_LOG_QUEUE_BYTES {
+					if *queue <= MAX_LOG_QUEUE_BYTES &&
+						(*queue + bytes as i64) > MAX_LOG_QUEUE_BYTES
+					{
 						self.log_queue_wait.cv.notify_one();
 					}
 					log::debug!(target: "parity-db", "Log queue size: {} bytes", *queue);
@@ -668,7 +698,7 @@ impl DbInner {
 	fn replay_all_logs(&mut self) -> Result<()> {
 		while let Some(id) = self.log.replay_next()? {
 			log::debug!(target: "parity-db", "Replaying database log {}", id);
-			while self.enact_logs(true)? { }
+			while self.enact_logs(true)? {}
 		}
 		// Re-read any cached metadata
 		for c in self.columns.iter() {
@@ -693,17 +723,17 @@ impl DbInner {
 				// On error the log reader may be left in inconsistent state. So it is important
 				// to no attempt any further log enactment.
 				log::debug!(target: "parity-db", "Shutdown with error state {}", err);
-				return Ok(());
+				return Ok(())
 			}
 		}
 		log::debug!(target: "parity-db", "Processing leftover commits");
 		// Finish logged records and proceed to log and enact queued commits.
-		while self.enact_logs(false)? {};
+		while self.enact_logs(false)? {}
 		self.flush_logs(0)?;
-		while self.process_commits()? {};
-		while self.enact_logs(false)? {};
+		while self.process_commits()? {}
+		while self.enact_logs(false)? {}
 		self.flush_logs(0)?;
-		while self.enact_logs(false)? {};
+		while self.enact_logs(false)? {}
 		self.clean_all_logs()?;
 		self.log.kill_logs()?;
 		if self.options.stats {
@@ -713,7 +743,7 @@ impl DbInner {
 				Ok(file) => {
 					let mut writer = std::io::BufWriter::new(file);
 					self.collect_stats(&mut writer, None)
-				}
+				},
 				Err(e) => log::warn!(target: "parity-db", "Error creating stats file: {:?}", e),
 			}
 		}
@@ -743,7 +773,7 @@ impl DbInner {
 	fn store_err(&self, result: Result<()>) {
 		if let Err(e) = result {
 			log::warn!(target: "parity-db", "Background worker error: {}", e);
-			let mut err =  self.bg_err.lock();
+			let mut err = self.bg_err.lock();
 			if err.is_none() {
 				*err = Some(Arc::new(e));
 				self.shutdown();
@@ -772,7 +802,7 @@ pub struct Db {
 impl Db {
 	pub fn with_columns(path: &std::path::Path, num_columns: u8) -> Result<Db> {
 		let options = Options::with_columns(path, num_columns);
-		let inner_options = InternalOptions { create: true,  ..Default::default() };
+		let inner_options = InternalOptions { create: true, ..Default::default() };
 		Self::open_inner(&options, &inner_options)
 	}
 
@@ -793,10 +823,7 @@ impl Db {
 		Self::open_inner(options, &inner_options)
 	}
 
-	fn open_inner(
-		options: &Options,
-		inner_options: &InternalOptions,
-	) -> Result<Db> {
+	fn open_inner(options: &Options, inner_options: &InternalOptions) -> Result<Db> {
 		assert!(options.is_valid());
 		let mut db = DbInner::open(options, inner_options)?;
 		// This needs to be call before log thread: so first reindexing
@@ -813,41 +840,43 @@ impl Db {
 				join_on_shutdown: inner_options.commit_stages.join_on_shutdown(),
 			})
 		}
-		let start_threads = matches!(inner_options.commit_stages, EnableCommitPipelineStages::Standard);
+		let start_threads =
+			matches!(inner_options.commit_stages, EnableCommitPipelineStages::Standard);
 		let commit_thread = if start_threads {
 			let commit_worker_db = db.clone();
-			Some(std::thread::spawn(move ||
+			Some(std::thread::spawn(move || {
 				commit_worker_db.store_err(Self::commit_worker(commit_worker_db.clone()))
-			))
+			}))
 		} else {
 			None
 		};
 		let flush_thread = if start_threads {
 			let flush_worker_db = db.clone();
-			let min_log_size = if matches!(inner_options.commit_stages, EnableCommitPipelineStages::DbFile) {
-				0
-			} else {
-				MIN_LOG_SIZE_BYTES
-			};
-			Some(std::thread::spawn(move ||
+			let min_log_size =
+				if matches!(inner_options.commit_stages, EnableCommitPipelineStages::DbFile) {
+					0
+				} else {
+					MIN_LOG_SIZE_BYTES
+				};
+			Some(std::thread::spawn(move || {
 				flush_worker_db.store_err(Self::flush_worker(flush_worker_db.clone(), min_log_size))
-			))
+			}))
 		} else {
 			None
 		};
 		let log_thread = if start_threads {
 			let log_worker_db = db.clone();
-			Some(std::thread::spawn(move ||
+			Some(std::thread::spawn(move || {
 				log_worker_db.store_err(Self::log_worker(log_worker_db.clone()))
-			))
+			}))
 		} else {
 			None
 		};
 		let cleanup_thread = if start_threads {
 			let cleanup_worker_db = db.clone();
-			Some(std::thread::spawn(move ||
+			Some(std::thread::spawn(move || {
 				cleanup_worker_db.store_err(Self::cleanup_worker(cleanup_worker_db.clone()))
-			))
+			}))
 		} else {
 			None
 		};
@@ -875,7 +904,7 @@ impl Db {
 
 	pub fn commit<I, K>(&self, tx: I) -> Result<()>
 	where
-		I: IntoIterator<Item=(ColId, K, Option<Value>)>,
+		I: IntoIterator<Item = (ColId, K, Option<Value>)>,
 		K: AsRef<[u8]>,
 	{
 		self.inner.commit(tx)
@@ -991,10 +1020,7 @@ pub struct CommitOverlay {
 
 impl CommitOverlay {
 	fn new() -> Self {
-		CommitOverlay {
-			indexed: Default::default(),
-			btree_indexed: Default::default(),
-		}
+		CommitOverlay { indexed: Default::default(), btree_indexed: Default::default() }
 	}
 
 	#[cfg(test)]
@@ -1020,19 +1046,26 @@ impl CommitOverlay {
 		self.btree_indexed.get(key).map(|(_, v)| v.as_ref())
 	}
 
-	pub fn btree_next(&self, last_key: &Option<Vec<u8>>, from_seek: bool) -> Option<(Value, Option<Value>)> {
+	pub fn btree_next(
+		&self,
+		last_key: &Option<Vec<u8>>,
+		from_seek: bool,
+	) -> Option<(Value, Option<Value>)> {
 		if let Some(key) = last_key.as_ref() {
 			let mut iter = self.btree_indexed.range::<Vec<u8>, _>(key..);
 			if let Some((k, (_, v))) = iter.next() {
 				if from_seek || k != key {
-					return Some((k.clone(), v.clone()));
+					return Some((k.clone(), v.clone()))
 				}
 			} else {
-				return None;
+				return None
 			}
 			iter.next().map(|(k, (_, v))| (k.clone(), v.clone()))
 		} else {
-			self.btree_indexed.range::<Vec<u8>, _>(..).next().map(|(k, (_, v))| (k.clone(), v.clone()))
+			self.btree_indexed
+				.range::<Vec<u8>, _>(..)
+				.next()
+				.map(|(k, (_, v))| (k.clone(), v.clone()))
 		}
 	}
 }
@@ -1053,17 +1086,23 @@ impl IndexedChangeSet {
 		IndexedChangeSet { col, changes: Default::default() }
 	}
 
-	fn push(&mut self, key: &[u8], v: Option<Value>, options: &Options, db_version :u32) {
+	fn push(&mut self, key: &[u8], v: Option<Value>, options: &Options, db_version: u32) {
 		let salt = options.salt.unwrap_or_default();
 		let k = hash_key(key, &salt, options.columns[self.col as usize].uniform, db_version);
 		self.changes.push((k, v));
 	}
 
-	fn copy_to_overlay(&self, overlay: &mut CommitOverlay, record_id: u64, bytes: &mut usize, options: &Options) {
+	fn copy_to_overlay(
+		&self,
+		overlay: &mut CommitOverlay,
+		record_id: u64,
+		bytes: &mut usize,
+		options: &Options,
+	) {
 		let ref_counted = options.columns[self.col as usize].ref_counted;
 		for (k, v) in self.changes.iter() {
 			*bytes += k.len();
-			*bytes += v.as_ref().map_or(0, |v|v.len());
+			*bytes += v.as_ref().map_or(0, |v| v.len());
 			// Don't add removed ref-counted values to overlay.
 			if !ref_counted || v.is_some() {
 				overlay.indexed.insert(*k, (record_id, v.clone()));
@@ -1082,14 +1121,16 @@ impl IndexedChangeSet {
 			Column::Hash(column) => column,
 			Column::Tree(_) => {
 				log::warn!(target: "parity-db", "Skipping unindex commit in indexed column");
-				return Ok(());
+				return Ok(())
 			},
 		};
 		for (key, value) in self.changes.iter() {
-			if let PlanOutcome::NeedReindex = column.write_plan(key, value.as_ref().map(|v| v.as_slice()), writer)? {
-					// Reindex has triggered another reindex.
-					*reindex = true;
-				}
+			if let PlanOutcome::NeedReindex =
+				column.write_plan(key, value.as_ref().map(|v| v.as_slice()), writer)?
+			{
+				// Reindex has triggered another reindex.
+				*reindex = true;
+			}
 			*ops += 1;
 		}
 		Ok(())
@@ -1138,12 +1179,7 @@ pub mod check {
 			} else {
 				CheckDisplay::None
 			};
-			CheckOptions {
-				column,
-				from,
-				bound,
-				display,
-			}
+			CheckOptions { column, from, bound, display }
 		}
 	}
 }
@@ -1183,16 +1219,15 @@ impl EnableCommitPipelineStages {
 	fn run_stages(&self, db: &Db) {
 		let db = &db.inner;
 		match self {
-			EnableCommitPipelineStages::DbFile
-			| EnableCommitPipelineStages::LogOverlay => {
-				while db.process_commits().unwrap() { }
-				while db.process_reindex().unwrap() { }
+			EnableCommitPipelineStages::DbFile | EnableCommitPipelineStages::LogOverlay => {
+				while db.process_commits().unwrap() {}
+				while db.process_reindex().unwrap() {}
 			},
 			_ => (),
 		}
 		match self {
 			EnableCommitPipelineStages::DbFile => {
-				while db.enact_logs(false).unwrap() { }
+				while db.enact_logs(false).unwrap() {}
 				let (_, _, cleanup_next) = db.log.flush_one(0).unwrap();
 				if cleanup_next {
 					let _ = db.clean_logs().unwrap();
@@ -1205,25 +1240,24 @@ impl EnableCommitPipelineStages {
 	#[cfg(test)]
 	fn check_empty_overlay(&self, db: &DbInner, col: ColId) -> bool {
 		match self {
-			EnableCommitPipelineStages::DbFile
-			| EnableCommitPipelineStages::LogOverlay => {
-			 if let Some(overlay) = db.commit_overlay.read().get(col as usize) {
-				if !overlay.is_empty() {
-					let mut replayed = 5;
-					while !overlay.is_empty() {
-						if replayed > 0 {
-							replayed -= 1;
-							// the signal is triggered just before cleaning the overlay, so
-							// we wait a bit.
-							// Warning this is still rather flaky and should be ignored
-							// or removed.
-							std::thread::sleep(std::time::Duration::from_millis(100));
-						} else {
-							return false;
+			EnableCommitPipelineStages::DbFile | EnableCommitPipelineStages::LogOverlay => {
+				if let Some(overlay) = db.commit_overlay.read().get(col as usize) {
+					if !overlay.is_empty() {
+						let mut replayed = 5;
+						while !overlay.is_empty() {
+							if replayed > 0 {
+								replayed -= 1;
+								// the signal is triggered just before cleaning the overlay, so
+								// we wait a bit.
+								// Warning this is still rather flaky and should be ignored
+								// or removed.
+								std::thread::sleep(std::time::Duration::from_millis(100));
+							} else {
+								return false
+							}
 						}
 					}
 				}
-			 }
 			},
 			_ => (),
 		}
@@ -1237,33 +1271,28 @@ impl EnableCommitPipelineStages {
 
 #[cfg(test)]
 mod tests {
-	use super::{Db, Options, EnableCommitPipelineStages, InternalOptions};
-	use tempfile::tempdir;
+	use super::{Db, EnableCommitPipelineStages, InternalOptions, Options};
 	use std::collections::BTreeMap;
+	use tempfile::tempdir;
 
 	#[test]
 	fn test_db_open_should_fail() {
 		let tmp = tempdir().unwrap();
 		let options = Options::with_columns(tmp.path(), 5);
-		assert!(
-			Db::open(&options).is_err(),
-			"Database does not exist, so it should fail to open"
-		);
-		assert!(Db::open(&options).map(|_| ()).unwrap_err().to_string().contains("use open_or_create"));
+		assert!(Db::open(&options).is_err(), "Database does not exist, so it should fail to open");
+		assert!(Db::open(&options)
+			.map(|_| ())
+			.unwrap_err()
+			.to_string()
+			.contains("use open_or_create"));
 	}
 
 	#[test]
 	fn test_db_open_or_create() {
 		let tmp = tempdir().unwrap();
 		let options = Options::with_columns(tmp.path(), 5);
-		assert!(
-			Db::open_or_create(&options).is_ok(),
-			"New database should be created"
-		);
-		assert!(
-			Db::open(&options).is_ok(),
-			"Existing database should be reopened"
-		);
+		assert!(Db::open_or_create(&options).is_ok(), "New database should be created");
+		assert!(Db::open(&options).is_ok(), "Existing database should be reopened");
 	}
 
 	#[test]
@@ -1288,9 +1317,7 @@ mod tests {
 		let db = Db::open_inner(&options, &inner_options).unwrap();
 		assert!(db.get(col_nb, key1.as_slice()).unwrap().is_none());
 
-		db.commit(vec![
-			(col_nb, key1.clone(), Some(b"value1".to_vec())),
-		]).unwrap();
+		db.commit(vec![(col_nb, key1.clone(), Some(b"value1".to_vec()))]).unwrap();
 		db_test.run_stages(&db);
 		assert!(db_test.check_empty_overlay(&db.inner, col_nb));
 
@@ -1300,7 +1327,8 @@ mod tests {
 			(col_nb, key1.clone(), None),
 			(col_nb, key2.clone(), Some(b"value2".to_vec())),
 			(col_nb, key3.clone(), Some(b"value3".to_vec())),
-		]).unwrap();
+		])
+		.unwrap();
 		db_test.run_stages(&db);
 		assert!(db_test.check_empty_overlay(&db.inner, col_nb));
 
@@ -1311,7 +1339,8 @@ mod tests {
 		db.commit(vec![
 			(col_nb, key2.clone(), Some(b"value2b".to_vec())),
 			(col_nb, key3.clone(), None),
-		]).unwrap();
+		])
+		.unwrap();
 		db_test.run_stages(&db);
 		assert!(db_test.check_empty_overlay(&db.inner, col_nb));
 
@@ -1340,7 +1369,8 @@ mod tests {
 			(col_nb, key1.clone(), Some(b"value1".to_vec())),
 			(col_nb, key2.clone(), Some(b"value2".to_vec())),
 			(col_nb, key3.clone(), Some(b"value3".to_vec())),
-		]).unwrap();
+		])
+		.unwrap();
 		db_test.run_stages(&db);
 		std::mem::drop(db);
 
@@ -1359,7 +1389,8 @@ mod tests {
 		db.commit(vec![
 			(col_nb, key2.clone(), Some(b"value2b".to_vec())),
 			(col_nb, key3.clone(), None),
-		]).unwrap();
+		])
+		.unwrap();
 		db_test.run_stages(&db);
 
 		assert_eq!(db.get(col_nb, key1.as_slice()).unwrap(), Some(b"value1".to_vec()));
@@ -1385,22 +1416,12 @@ mod tests {
 		options.columns[col_nb as usize].btree_index = true;
 
 		let (key1, key2, key3, key4) = if !long_key {
-			(
-				b"key1".to_vec(),
-				b"key2".to_vec(),
-				b"key3".to_vec(),
-				b"key4".to_vec(),
-			)
+			(b"key1".to_vec(), b"key2".to_vec(), b"key3".to_vec(), b"key4".to_vec())
 		} else {
 			let key2 = vec![2; 272];
 			let mut key3 = key2.clone();
 			key3[271] = 3;
-			(
-				vec![1; 953],
-				key2,
-				key3,
-				vec![4; 79],
-			)
+			(vec![1; 953], key2, key3, vec![4; 79])
 		};
 
 		let mut inner_options = InternalOptions::default();
@@ -1412,9 +1433,7 @@ mod tests {
 		let mut iter = db.iter(col_nb).unwrap();
 		assert_eq!(iter.next().unwrap(), None);
 
-		db.commit(vec![
-			(col_nb, key1.clone(), Some(b"value1".to_vec())),
-		]).unwrap();
+		db.commit(vec![(col_nb, key1.clone(), Some(b"value1".to_vec()))]).unwrap();
 		db_test.run_stages(&db);
 
 		assert_eq!(db.get(col_nb, &key1).unwrap(), Some(b"value1".to_vec()));
@@ -1426,7 +1445,8 @@ mod tests {
 			(col_nb, key1.clone(), None),
 			(col_nb, key2.clone(), Some(b"value2".to_vec())),
 			(col_nb, key3.clone(), Some(b"value3".to_vec())),
-		]).unwrap();
+		])
+		.unwrap();
 		db_test.run_stages(&db);
 
 		assert_eq!(db.get(col_nb, &key1).unwrap(), None);
@@ -1441,7 +1461,8 @@ mod tests {
 			(col_nb, key2.clone(), Some(b"value2b".to_vec())),
 			(col_nb, key4.clone(), Some(b"value4".to_vec())),
 			(col_nb, key3.clone(), None),
-		]).unwrap();
+		])
+		.unwrap();
 		db_test.run_stages(&db);
 
 		assert_eq!(db.get(col_nb, &key1).unwrap(), None);
@@ -1478,9 +1499,7 @@ mod tests {
 		assert_eq!(db.get(col_nb, &key1).unwrap(), None);
 		assert_eq!(iter.next().unwrap(), None);
 
-		db.commit(vec![
-			(col_nb, key1.clone(), Some(b"value1".to_vec())),
-		]).unwrap();
+		db.commit(vec![(col_nb, key1.clone(), Some(b"value1".to_vec()))]).unwrap();
 		EnableCommitPipelineStages::DbFile.run_stages(&db);
 		std::mem::drop(db);
 
@@ -1503,7 +1522,8 @@ mod tests {
 			(col_nb, key1.clone(), None),
 			(col_nb, key2.clone(), Some(b"value2".to_vec())),
 			(col_nb, key3.clone(), Some(b"value3".to_vec())),
-		]).unwrap();
+		])
+		.unwrap();
 		db_test.run_stages(&db);
 
 		assert_eq!(db.get(col_nb, &key1).unwrap(), None);
@@ -1529,10 +1549,12 @@ mod tests {
 		let mut iter = db.iter(col_nb).unwrap();
 		assert_eq!(iter.next().unwrap(), None);
 
-		db.commit(change_set.iter().map(|(k, v)| (col_nb, k.clone(), v.clone()))).unwrap();
+		db.commit(change_set.iter().map(|(k, v)| (col_nb, k.clone(), v.clone())))
+			.unwrap();
 		db_test.run_stages(&db);
 
-		let state: BTreeMap<Vec<u8>, Option<Vec<u8>>> = change_set.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+		let state: BTreeMap<Vec<u8>, Option<Vec<u8>>> =
+			change_set.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 		for (key, value) in state.iter() {
 			assert_eq!(&db.get(col_nb, &key).unwrap(), value);
 		}
@@ -1761,8 +1783,8 @@ mod tests {
 			}
 		}
 
-		let start_state: BTreeMap<Vec<u8>, Vec<u8>> = data_start.iter().cloned()
-			.map(|(_c, k, v)| (k, v.unwrap())).collect();
+		let start_state: BTreeMap<Vec<u8>, Vec<u8>> =
+			data_start.iter().cloned().map(|(_c, k, v)| (k, v.unwrap())).collect();
 		let mut end_state: BTreeMap<Vec<u8>, Vec<u8>> = start_state.clone();
 		for (_c, k, v) in data_change.iter() {
 			if let Some(v) = v {
@@ -1779,17 +1801,22 @@ mod tests {
 			EnableCommitPipelineStages::Standard,
 		] {
 			for i in 0..10 {
-				test_btree_iter_inner(stage, &data_start, &data_change, &start_state, &end_state, i * 5);
+				test_btree_iter_inner(
+					stage,
+					&data_start,
+					&data_change,
+					&start_state,
+					&end_state,
+					i * 5,
+				);
 			}
 			let data_start = vec![
 				(0, b"key1".to_vec(), Some(b"val1".to_vec())),
 				(0, b"key3".to_vec(), Some(b"val3".to_vec())),
 			];
-			let data_change = vec![
-				(0, b"key2".to_vec(), Some(b"val2".to_vec())),
-			];
-			let start_state: BTreeMap<Vec<u8>, Vec<u8>> = data_start.iter().cloned()
-				.map(|(_c, k, v)| (k, v.unwrap())).collect();
+			let data_change = vec![(0, b"key2".to_vec(), Some(b"val2".to_vec()))];
+			let start_state: BTreeMap<Vec<u8>, Vec<u8>> =
+				data_start.iter().cloned().map(|(_c, k, v)| (k, v.unwrap())).collect();
 			let mut end_state: BTreeMap<Vec<u8>, Vec<u8>> = start_state.clone();
 			for (_c, k, v) in data_change.iter() {
 				if let Some(v) = v {

--- a/src/display.rs
+++ b/src/display.rs
@@ -18,7 +18,9 @@
 pub struct HexDisplay<'a>(&'a [u8]);
 
 impl<'a> HexDisplay<'a> {
-	pub fn from<R: std::convert::AsRef<[u8]> + ?Sized>(d: &'a R) -> Self { HexDisplay(d.as_ref()) }
+	pub fn from<R: std::convert::AsRef<[u8]> + ?Sized>(d: &'a R) -> Self {
+		HexDisplay(d.as_ref())
+	}
 }
 
 impl<'a> std::fmt::Display for HexDisplay<'a> {

--- a/src/display.rs
+++ b/src/display.rs
@@ -39,6 +39,6 @@ impl<'a> std::fmt::Debug for HexDisplay<'a> {
 	}
 }
 
-pub fn hex<'a, R: std::convert::AsRef<[u8]> + ?Sized>(r: &'a R) -> HexDisplay<'a> {
+pub fn hex<R: std::convert::AsRef<[u8]> + ?Sized>(r: &R) -> HexDisplay<'_> {
 	HexDisplay::from(r)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::fmt;
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -34,7 +33,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			Error::Io(e) => write!(f, "IO Error: {}", e),
 			Error::Corruption(e) => write!(f, "Corruption: {}", e),
@@ -47,7 +46,7 @@ impl fmt::Display for Error {
 			Error::Compression => write!(f, "Compression error"),
 			Error::DatabaseNotFound => write!(f, "Database does not exist"),
 		}
-    }
+	}
 }
 
 impl From<std::io::Error> for Error {

--- a/src/file.rs
+++ b/src/file.rs
@@ -26,7 +26,7 @@ fn disable_read_ahead(file: &std::fs::File) -> Result<()> {
 	use std::os::unix::io::AsRawFd;
 	let err = unsafe { libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_RANDOM) };
 	if err != 0 {
-		Err(std::io::Error::from_raw_os_error(err))?
+		Err(std::io::Error::from_raw_os_error(err).into())
 	} else {
 		Ok(())
 	}
@@ -162,7 +162,7 @@ impl TableFile {
 	pub fn flush(&self) -> Result<()> {
 		if let Ok(true) = self.dirty.compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed) {
 			if let Some(file) = self.file.read().as_ref() {
-				fsync(&file)?;
+				fsync(file)?;
 			}
 		}
 		Ok(())

--- a/src/file.rs
+++ b/src/file.rs
@@ -14,12 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::{error::Result, table::TableId};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 /// Utilites for db file.
-
-use std::sync::atomic::{AtomicU64, AtomicBool, Ordering};
-use parking_lot::{RwLockUpgradableReadGuard, RwLock};
-use crate::error::Result;
-use crate::table::TableId;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 #[cfg(target_os = "linux")]
 fn disable_read_ahead(file: &std::fs::File) -> Result<()> {
@@ -70,7 +68,6 @@ fn fsync(file: &std::fs::File) -> Result<()> {
 	Ok(())
 }
 
-
 const GROW_SIZE_BYTES: u64 = 256 * 1024;
 
 pub struct TableFile {
@@ -85,7 +82,11 @@ impl TableFile {
 	pub fn open(filepath: std::path::PathBuf, entry_size: u16, id: TableId) -> Result<Self> {
 		let mut capacity = 0u64;
 		let file = if std::fs::metadata(&filepath).is_ok() {
-			let file = std::fs::OpenOptions::new().create(true).read(true).write(true).open(filepath.as_path())?;
+			let file = std::fs::OpenOptions::new()
+				.create(true)
+				.read(true)
+				.write(true)
+				.open(filepath.as_path())?;
 			disable_read_ahead(&file)?;
 			let len = file.metadata()?.len();
 			if len == 0 {
@@ -110,7 +111,11 @@ impl TableFile {
 
 	fn create_file(&self) -> Result<std::fs::File> {
 		log::debug!(target: "parity-db", "Created value table {}", self.id);
-		let file = std::fs::OpenOptions::new().create(true).read(true).write(true).open(self.path.as_path())?;
+		let file = std::fs::OpenOptions::new()
+			.create(true)
+			.read(true)
+			.write(true)
+			.open(self.path.as_path())?;
 		disable_read_ahead(&file)?;
 		Ok(file)
 	}
@@ -160,7 +165,9 @@ impl TableFile {
 	}
 
 	pub fn flush(&self) -> Result<()> {
-		if let Ok(true) = self.dirty.compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed) {
+		if let Ok(true) =
+			self.dirty.compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+		{
 			if let Some(file) = self.file.read().as_ref() {
 				fsync(file)?;
 			}

--- a/src/index.rs
+++ b/src/index.rs
@@ -313,7 +313,7 @@ impl IndexTable {
 	fn transmute_chunk(chunk: [u8; CHUNK_LEN]) -> [Entry; CHUNK_ENTRIES] {
 		let mut result: [Entry; CHUNK_ENTRIES] = unsafe { std::mem::transmute(chunk) };
 		if !cfg!(target_endian = "little") {
-			for item in result.iter_mut().take(CHUNK_ENTRIES) {
+			for item in result.iter_mut() {
 				*item = Entry::from_u64(u64::from_le(item.0));
 			}
 		}

--- a/src/index.rs
+++ b/src/index.rs
@@ -14,17 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::convert::TryInto;
-use parking_lot::{RwLockUpgradableReadGuard, RwLock};
 use crate::{
-	Key,
-	error::{Error, Result},
 	column::ColId,
-	log::{LogReader, LogWriter, LogQuery},
 	display::hex,
+	error::{Error, Result},
+	log::{LogQuery, LogReader, LogWriter},
 	stats::{self, ColumnStats},
 	table::{key::TableKey, SIZE_TIERS_BITS},
+	Key,
 };
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use std::convert::TryInto;
 
 // Index chunk consists of 8 64-bit entries.
 const CHUNK_LEN: usize = CHUNK_ENTRIES * ENTRY_BYTES; // 512 bytes
@@ -152,7 +152,7 @@ pub struct TableId(u16);
 
 impl TableId {
 	pub fn new(col: ColId, index_bits: u8) -> TableId {
-		TableId(((col as u16) << 8)| (index_bits as u16))
+		TableId(((col as u16) << 8) | (index_bits as u16))
 	}
 
 	pub fn from_u16(id: u16) -> TableId {
@@ -201,8 +201,8 @@ impl IndexTable {
 
 		let file = match std::fs::OpenOptions::new().read(true).write(true).open(path.as_path()) {
 			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-				return Ok(None);
-			}
+				return Ok(None)
+			},
 			Err(e) => return Err(e.into()),
 			Ok(file) => file,
 		};
@@ -210,53 +210,45 @@ impl IndexTable {
 		file.set_len(file_size(id.index_bits()))?;
 		let map = unsafe { memmap2::MmapMut::map_mut(&file)? };
 		log::debug!(target: "parity-db", "Opened existing index {}", id);
-		Ok(Some(IndexTable {
-			id,
-			path,
-			map: RwLock::new(Some(map)),
-		}))
+		Ok(Some(IndexTable { id, path, map: RwLock::new(Some(map)) }))
 	}
 
 	pub fn create_new(path: &std::path::Path, id: TableId) -> IndexTable {
 		let mut path: std::path::PathBuf = path.into();
 		path.push(id.file_name());
-		IndexTable {
-			id,
-			path,
-			map: RwLock::new(None),
-		}
+		IndexTable { id, path, map: RwLock::new(None) }
 	}
 
 	pub fn load_stats(&self) -> ColumnStats {
-        // NOTE: this const assertion will be optimized out by the compiler
+		// NOTE: this const assertion will be optimized out by the compiler
 		debug_assert!(META_SIZE >= HEADER_SIZE + stats::TOTAL_SIZE);
 		if let Some(map) = &*self.map.read() {
-			ColumnStats::from_slice(&map[HEADER_SIZE .. HEADER_SIZE + stats::TOTAL_SIZE])
+			ColumnStats::from_slice(&map[HEADER_SIZE..HEADER_SIZE + stats::TOTAL_SIZE])
 		} else {
 			ColumnStats::empty()
 		}
 	}
 
 	pub fn write_stats(&self, stats: &ColumnStats) {
-        // NOTE: this const assertion will be optimized out by the compiler
+		// NOTE: this const assertion will be optimized out by the compiler
 		debug_assert!(META_SIZE >= HEADER_SIZE + stats::TOTAL_SIZE);
 		if let Some(map) = &mut *self.map.write() {
-			let slice = &mut map[HEADER_SIZE .. HEADER_SIZE + stats::TOTAL_SIZE];
+			let slice = &mut map[HEADER_SIZE..HEADER_SIZE + stats::TOTAL_SIZE];
 			stats.to_slice(slice);
 		}
 	}
 
 	fn chunk_at(index: u64, map: &memmap2::MmapMut) -> &[u8] {
 		let offset = META_SIZE + index as usize * CHUNK_LEN;
-		&map[offset .. offset + CHUNK_LEN]
+		&map[offset..offset + CHUNK_LEN]
 	}
 
 	fn find_entry(&self, key_prefix: u64, sub_index: usize, chunk: &[u8]) -> (Entry, usize) {
 		let partial_key = Entry::extract_key(key_prefix, self.id.index_bits());
-		for i in sub_index .. CHUNK_ENTRIES {
+		for i in sub_index..CHUNK_ENTRIES {
 			let entry = Self::read_entry(chunk, i);
 			if !entry.is_empty() && entry.partial_key(self.id.index_bits()) == partial_key {
-				return (entry, i);
+				return (entry, i)
 			}
 		}
 		(Entry::empty(), 0)
@@ -267,8 +259,8 @@ impl IndexTable {
 		// Restore first 54 bits of the key.
 		let partial_key = entry.partial_key(self.id.index_bits());
 		let k = 64 - Entry::address_bits(self.id.index_bits());
-		let index_key = (chunk << 64 - self.id.index_bits()) |
-			(partial_key << (64 - k - self.id.index_bits()));
+		let index_key =
+			(chunk << 64 - self.id.index_bits()) | (partial_key << (64 - k - self.id.index_bits()));
 		let mut key = Key::default();
 		key[0..8].copy_from_slice(&index_key.to_be_bytes());
 		key
@@ -280,31 +272,31 @@ impl IndexTable {
 		let chunk_index = self.chunk_index(key);
 
 		if let Some(entry) = log.with_index(self.id, chunk_index, |chunk| {
-				log::trace!(target: "parity-db", "{}: Querying overlay at {}", self.id, chunk_index);
-				self.find_entry(key, sub_index, chunk)
-			}) {
-			return entry;
+			log::trace!(target: "parity-db", "{}: Querying overlay at {}", self.id, chunk_index);
+			self.find_entry(key, sub_index, chunk)
+		}) {
+			return entry
 		}
 
 		if let Some(map) = &*self.map.read() {
 			log::trace!(target: "parity-db", "{}: Querying chunk at {}", self.id, chunk_index);
 			let chunk = Self::chunk_at(chunk_index, map);
-			return self.find_entry(key, sub_index, chunk);
-
+			return self.find_entry(key, sub_index, chunk)
 		}
 		(Entry::empty(), 0)
 	}
 
 	pub fn entries(&self, chunk_index: u64, log: &impl LogQuery) -> [Entry; CHUNK_ENTRIES] {
 		let mut chunk = [0; CHUNK_LEN];
-		if let Some(entry) = log.with_index(self.id, chunk_index, |chunk|
-			Self::transmute_chunk(*chunk)) {
-			return entry;
+		if let Some(entry) =
+			log.with_index(self.id, chunk_index, |chunk| Self::transmute_chunk(*chunk))
+		{
+			return entry
 		}
 		if let Some(map) = &*self.map.read() {
 			let source = Self::chunk_at(chunk_index, map);
 			chunk.copy_from_slice(source);
-			return Self::transmute_chunk(chunk);
+			return Self::transmute_chunk(chunk)
 		}
 		Self::transmute_chunk(EMPTY_CHUNK)
 	}
@@ -322,12 +314,12 @@ impl IndexTable {
 
 	#[inline(always)]
 	fn write_entry(entry: &Entry, at: usize, chunk: &mut [u8; CHUNK_LEN]) {
-		chunk[at * 8 .. at * 8 + 8].copy_from_slice(&entry.as_u64().to_le_bytes());
+		chunk[at * 8..at * 8 + 8].copy_from_slice(&entry.as_u64().to_le_bytes());
 	}
 
 	#[inline(always)]
 	fn read_entry(chunk: &[u8], at: usize) -> Entry {
-		Entry::from_u64(u64::from_le_bytes(chunk[at * 8 .. at * 8 + 8].try_into().unwrap()))
+		Entry::from_u64(u64::from_le_bytes(chunk[at * 8..at * 8 + 8].try_into().unwrap()))
 	}
 
 	#[inline(always)]
@@ -347,7 +339,7 @@ impl IndexTable {
 		if address.as_u64() > Entry::last_address(self.id.index_bits()) {
 			// Address overflow
 			log::warn!(target: "parity-db", "{}: Address space overflow at {}: {}", self.id, chunk_index, address);
-			return Ok(PlanOutcome::NeedReindex);
+			return Ok(PlanOutcome::NeedReindex)
 		}
 		let mut chunk = [0; CHUNK_LEN];
 		chunk.copy_from_slice(source);
@@ -355,26 +347,35 @@ impl IndexTable {
 		let new_entry = Entry::new(address, partial_key, self.id.index_bits());
 		if let Some(i) = sub_index {
 			let entry = Self::read_entry(&chunk, i);
-			assert!(entry.partial_key(self.id.index_bits()) == new_entry.partial_key(self.id.index_bits()));
+			assert!(
+				entry.partial_key(self.id.index_bits()) ==
+					new_entry.partial_key(self.id.index_bits())
+			);
 			Self::write_entry(&new_entry, i, &mut chunk);
 			log::trace!(target: "parity-db", "{}: Replaced at {}.{}: {}", self.id, chunk_index, i, new_entry.address(self.id.index_bits()));
 			log.insert_index(self.id, chunk_index, i as u8, &chunk);
-			return Ok(PlanOutcome::Written);
+			return Ok(PlanOutcome::Written)
 		}
-		for i in 0 .. CHUNK_ENTRIES {
+		for i in 0..CHUNK_ENTRIES {
 			let entry = Self::read_entry(&chunk, i);
 			if entry.is_empty() {
 				Self::write_entry(&new_entry, i, &mut chunk);
 				log::trace!(target: "parity-db", "{}: Inserted at {}.{}: {}", self.id, chunk_index, i, new_entry.address(self.id.index_bits()));
 				log.insert_index(self.id, chunk_index, i as u8, &chunk);
-				return Ok(PlanOutcome::Written);
+				return Ok(PlanOutcome::Written)
 			}
 		}
 		log::trace!(target: "parity-db", "{}: Full at {}", self.id, chunk_index);
 		Ok(PlanOutcome::NeedReindex)
 	}
 
-	pub fn write_insert_plan(&self, key: &Key, address: Address, sub_index: Option<usize>, log: &mut LogWriter) -> Result<PlanOutcome> {
+	pub fn write_insert_plan(
+		&self,
+		key: &Key,
+		address: Address,
+		sub_index: Option<usize>,
+		log: &mut LogWriter,
+	) -> Result<PlanOutcome> {
 		log::trace!(target: "parity-db", "{}: Inserting {} -> {}", self.id, hex(key), address);
 		let key_prefix = TableKey::index_from_partial(key);
 		let chunk_index = self.chunk_index(key_prefix);
@@ -385,14 +386,20 @@ impl IndexTable {
 
 		if let Some(map) = &*self.map.read() {
 			let chunk = Self::chunk_at(chunk_index, map);
-			return self.plan_insert_chunk(key_prefix, address, chunk, sub_index, log);
+			return self.plan_insert_chunk(key_prefix, address, chunk, sub_index, log)
 		}
 
 		let chunk = &EMPTY_CHUNK;
 		self.plan_insert_chunk(key_prefix, address, chunk, sub_index, log)
 	}
 
-	fn plan_remove_chunk(&self, key_prefix: u64, source: &[u8], sub_index: usize, log: &mut LogWriter) -> Result<PlanOutcome> {
+	fn plan_remove_chunk(
+		&self,
+		key_prefix: u64,
+		source: &[u8],
+		sub_index: usize,
+		log: &mut LogWriter,
+	) -> Result<PlanOutcome> {
 		let mut chunk = [0; CHUNK_LEN];
 		chunk.copy_from_slice(source);
 		let chunk_index = self.chunk_index(key_prefix);
@@ -405,24 +412,29 @@ impl IndexTable {
 			Self::write_entry(&new_entry, i, &mut chunk);
 			log.insert_index(self.id, chunk_index, i as u8, &chunk);
 			log::trace!(target: "parity-db", "{}: Removed at {}.{}", self.id, chunk_index, i);
-			return Ok(PlanOutcome::Written);
+			return Ok(PlanOutcome::Written)
 		}
 		Ok(PlanOutcome::Skipped)
 	}
 
-	pub fn write_remove_plan(&self, key: &Key, sub_index: usize, log: &mut LogWriter) -> Result<PlanOutcome> {
+	pub fn write_remove_plan(
+		&self,
+		key: &Key,
+		sub_index: usize,
+		log: &mut LogWriter,
+	) -> Result<PlanOutcome> {
 		log::trace!(target: "parity-db", "{}: Removing {}", self.id, hex(key));
 		let key_prefix = TableKey::index_from_partial(key);
 
 		let chunk_index = self.chunk_index(key_prefix);
 
 		if let Some(chunk) = log.with_index(self.id, chunk_index, |chunk| *chunk) {
-			return self.plan_remove_chunk(key_prefix, &chunk, sub_index, log);
+			return self.plan_remove_chunk(key_prefix, &chunk, sub_index, log)
 		}
 
 		if let Some(map) = &*self.map.read() {
 			let chunk = Self::chunk_at(chunk_index, map);
-			return self.plan_remove_chunk(key_prefix, chunk, sub_index, log);
+			return self.plan_remove_chunk(key_prefix, chunk, sub_index, log)
 		}
 
 		Ok(PlanOutcome::Skipped)
@@ -432,7 +444,11 @@ impl IndexTable {
 		let mut map = self.map.upgradable_read();
 		if map.is_none() {
 			let mut wmap = RwLockUpgradableReadGuard::upgrade(map);
-			let file = std::fs::OpenOptions::new().write(true).read(true).create_new(true).open(self.path.as_path())?;
+			let file = std::fs::OpenOptions::new()
+				.write(true)
+				.read(true)
+				.create_new(true)
+				.open(self.path.as_path())?;
 			log::debug!(target: "parity-db", "Created new index {}", self.id);
 			//TODO: check for potential overflows on 32-bit platforms
 			file.set_len(file_size(self.id.index_bits()))?;
@@ -444,10 +460,10 @@ impl IndexTable {
 
 		let map = map.as_ref().unwrap();
 		let offset = META_SIZE + index as usize * CHUNK_LEN;
-		// Nasty mutable pointer cast. We do ensure that all chunks that are being written are accessed
-		// through the overlay in other threads.
+		// Nasty mutable pointer cast. We do ensure that all chunks that are being written are
+		// accessed through the overlay in other threads.
 		let ptr: *mut u8 = map.as_ptr() as *mut u8;
-		let chunk: &mut[u8] = unsafe {
+		let chunk: &mut [u8] = unsafe {
 			let ptr = ptr.add(offset);
 			std::slice::from_raw_parts_mut(ptr, CHUNK_LEN)
 		};
@@ -457,7 +473,7 @@ impl IndexTable {
 		while mask != 0 {
 			let i = mask.trailing_zeros();
 			mask &= !(1 << i);
-			log.read(&mut chunk[i as usize *ENTRY_BYTES .. (i as usize + 1)*ENTRY_BYTES])?;
+			log.read(&mut chunk[i as usize * ENTRY_BYTES..(i as usize + 1) * ENTRY_BYTES])?;
 		}
 		log::trace!(target: "parity-db", "{}: Enacted chunk {}", self.id, index);
 		Ok(())
@@ -465,7 +481,7 @@ impl IndexTable {
 
 	pub fn validate_plan(&self, index: u64, log: &mut LogReader) -> Result<()> {
 		if index >= self.id.total_entries() {
-			return Err(Error::Corruption("Bad index".into()));
+			return Err(Error::Corruption("Bad index".into()))
 		}
 		let mut buf = [0u8; 8];
 		log.read(&mut buf)?;
@@ -509,7 +525,11 @@ impl IndexTable {
 	#[cfg(unix)]
 	fn madvise_random(&self, map: &mut memmap2::MmapMut) {
 		unsafe {
-			libc::madvise(map.as_mut_ptr() as _, file_size(self.id.index_bits()) as usize, libc::MADV_RANDOM);
+			libc::madvise(
+				map.as_mut_ptr() as _,
+				file_size(self.id.index_bits()) as usize,
+				libc::MADV_RANDOM,
+			);
 		}
 	}
 
@@ -525,9 +545,11 @@ mod test {
 	fn test_entries() {
 		let mut chunk = IndexTable::transmute_chunk(EMPTY_CHUNK);
 		let mut chunk2 = EMPTY_CHUNK;
-		for i in 0 .. CHUNK_ENTRIES {
-			use std::collections::hash_map::DefaultHasher;
-			use std::hash::{Hash, Hasher};
+		for i in 0..CHUNK_ENTRIES {
+			use std::{
+				collections::hash_map::DefaultHasher,
+				hash::{Hash, Hasher},
+			};
 			let mut hasher = DefaultHasher::new();
 			i.hash(&mut hasher);
 			let hash = hasher.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,26 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-mod db;
-mod error;
-mod index;
-mod table;
-mod column;
 mod btree;
-mod file;
-mod log;
+mod column;
+mod compress;
+mod db;
 mod display;
+mod error;
+mod file;
+mod index;
+mod log;
+mod migration;
 mod options;
 mod stats;
-mod compress;
-mod migration;
+mod table;
 
-pub use db::{Db, Value, check::CheckOptions};
-pub use error::{Error, Result};
-pub use options::{ColumnOptions, Options};
-pub use migration::migrate;
-pub use compress::CompressionType;
 pub use btree::BTreeIterator;
+pub use compress::CompressionType;
+pub use db::{check::CheckOptions, Db, Value};
+pub use error::{Error, Result};
+pub use migration::migrate;
+pub use options::{ColumnOptions, Options};
 
 #[derive(Default)]
 pub struct IdentityKeyHash(u64);
@@ -43,17 +43,37 @@ impl std::hash::Hasher for IdentityKeyHash {
 	fn write(&mut self, bytes: &[u8]) {
 		self.0 = u64::from_le_bytes((&bytes[0..8]).try_into().unwrap())
 	}
-	fn write_u8(&mut self, _: u8)       { unreachable!() }
-	fn write_u16(&mut self, _: u16)     { unreachable!() }
-	fn write_u32(&mut self, _: u32)     { unreachable!() }
-	fn write_u64(&mut self, _: u64)     { unreachable!() }
-	fn write_usize(&mut self, _: usize) { }
-	fn write_i8(&mut self, _: i8)       { unreachable!() }
-	fn write_i16(&mut self, _: i16)     { unreachable!() }
-	fn write_i32(&mut self, _: i32)     { unreachable!() }
-	fn write_i64(&mut self, _: i64)     { unreachable!() }
-	fn write_isize(&mut self, _: isize) { unreachable!() }
-	fn finish(&self) -> u64 { self.0 }
+	fn write_u8(&mut self, _: u8) {
+		unreachable!()
+	}
+	fn write_u16(&mut self, _: u16) {
+		unreachable!()
+	}
+	fn write_u32(&mut self, _: u32) {
+		unreachable!()
+	}
+	fn write_u64(&mut self, _: u64) {
+		unreachable!()
+	}
+	fn write_usize(&mut self, _: usize) {}
+	fn write_i8(&mut self, _: i8) {
+		unreachable!()
+	}
+	fn write_i16(&mut self, _: i16) {
+		unreachable!()
+	}
+	fn write_i32(&mut self, _: i32) {
+		unreachable!()
+	}
+	fn write_i64(&mut self, _: i64) {
+		unreachable!()
+	}
+	fn write_isize(&mut self, _: isize) {
+		unreachable!()
+	}
+	fn finish(&self) -> u64 {
+		self.0
+	}
 }
 
 pub const KEY_SIZE: usize = 32;

--- a/src/log.rs
+++ b/src/log.rs
@@ -13,17 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{VecDeque, HashMap};
-use std::io::{Read, Write, Seek};
-use std::convert::TryInto;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU32, Ordering};
-use parking_lot::{Condvar, Mutex, RwLock, RwLockWriteGuard, MappedRwLockWriteGuard};
 use crate::{
-	error::{Error, Result},
-	table::TableId as ValueTableId,
-	index::{TableId as IndexTableId, Chunk as IndexChunk, ENTRY_BYTES},
-	options::Options,
 	column::ColId,
+	error::{Error, Result},
+	index::{Chunk as IndexChunk, TableId as IndexTableId, ENTRY_BYTES},
+	options::Options,
+	table::TableId as ValueTableId,
+};
+use parking_lot::{Condvar, MappedRwLockWriteGuard, Mutex, RwLock, RwLockWriteGuard};
+use std::{
+	collections::{HashMap, VecDeque},
+	convert::TryInto,
+	io::{Read, Seek, Write},
+	sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
 };
 
 const MAX_LOG_POOL_SIZE: usize = 16;
@@ -52,8 +54,13 @@ pub enum LogAction {
 }
 
 pub trait LogQuery {
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R> (&self, table: IndexTableId, index: u64, f: F) -> Option<R>;
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut[u8]) -> bool;
+	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
+		&self,
+		table: IndexTableId,
+		index: u64,
+		f: F,
+	) -> Option<R>;
+	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool;
 }
 
 #[derive(Default)]
@@ -70,23 +77,36 @@ impl LogOverlays {
 }
 
 impl LogQuery for RwLock<LogOverlays> {
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R> (&self, table: IndexTableId, index: u64, f: F) -> Option<R> {
+	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
+		&self,
+		table: IndexTableId,
+		index: u64,
+		f: F,
+	) -> Option<R> {
 		self.read().with_index(table, index, f)
 	}
 
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut[u8]) -> bool {
+	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool {
 		self.read().value(table, index, dest)
 	}
 }
 
 impl LogQuery for LogOverlays {
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R> (&self, table: IndexTableId, index: u64, f: F) -> Option<R> {
-		self.index.get(&table).and_then(|o| o.map.get(&index).map(|(_id, _mask, data)| f(data)))
+	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
+		&self,
+		table: IndexTableId,
+		index: u64,
+		f: F,
+	) -> Option<R> {
+		self.index
+			.get(&table)
+			.and_then(|o| o.map.get(&index).map(|(_id, _mask, data)| f(data)))
 	}
 
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut[u8]) -> bool {
+	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool {
 		let s = self;
-		if let Some(d) = s.value.get(&table).and_then(|o| o.map.get(&index).map(|(_id, data)| data)) {
+		if let Some(d) = s.value.get(&table).and_then(|o| o.map.get(&index).map(|(_id, data)| data))
+		{
 			let len = dest.len().min(d.len());
 			dest[0..len].copy_from_slice(&d[0..len]);
 			true
@@ -152,7 +172,7 @@ impl<'a> LogReader<'a> {
 		let mut buf = [0u8; 8];
 		read_buf(1, &mut buf)?;
 		match buf[0] {
-			BEGIN_RECORD =>  {
+			BEGIN_RECORD => {
 				read_buf(8, &mut buf)?;
 				let record_id = u64::from_le_bytes(buf);
 				self.record_id = record_id;
@@ -160,7 +180,8 @@ impl<'a> LogReader<'a> {
 			},
 			INSERT_INDEX => {
 				read_buf(2, &mut buf)?;
-				let table = IndexTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
+				let table =
+					IndexTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
 				read_buf(8, &mut buf)?;
 				let index = u64::from_le_bytes(buf);
 				self.cleared.index.push((table, index));
@@ -168,7 +189,8 @@ impl<'a> LogReader<'a> {
 			},
 			INSERT_VALUE => {
 				read_buf(2, &mut buf)?;
-				let table = ValueTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
+				let table =
+					ValueTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
 				read_buf(8, &mut buf)?;
 				let index = u64::from_le_bytes(buf);
 				self.cleared.values.push((table, index));
@@ -195,12 +217,11 @@ impl<'a> LogReader<'a> {
 			},
 			DROP_TABLE => {
 				read_buf(2, &mut buf)?;
-				let table = IndexTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
+				let table =
+					IndexTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
 				Ok(LogAction::DropTable(table))
 			},
-			_ => {
-				Err(Error::Corruption("Bad log entry type".into()))
-			},
+			_ => Err(Error::Corruption("Bad log entry type".into())),
 		}
 	}
 
@@ -230,9 +251,7 @@ pub struct LogChange {
 }
 
 impl LogChange {
-	fn new(
-		record_id: u64,
-	) -> LogChange {
+	fn new(record_id: u64) -> LogChange {
 		LogChange {
 			local_index: Default::default(),
 			local_values: Default::default(),
@@ -245,8 +264,10 @@ impl LogChange {
 		self.local_values.get(&id)
 	}
 
-	pub fn to_file(self, file: &mut std::io::BufWriter<std::fs::File>)
-		-> Result<(HashMap<IndexTableId, IndexLogOverlay>, HashMap<ValueTableId, ValueLogOverlay>, u64)>
+	pub fn to_file(
+		self,
+		file: &mut std::io::BufWriter<std::fs::File>,
+	) -> Result<(HashMap<IndexTableId, IndexLogOverlay>, HashMap<ValueTableId, ValueLogOverlay>, u64)>
 	{
 		let mut crc32 = crc32fast::Hasher::new();
 		let mut bytes: u64 = 0;
@@ -271,7 +292,7 @@ impl LogChange {
 				while mask != 0 {
 					let i = mask.trailing_zeros();
 					mask &= !(1 << i);
-					write(&chunk[i as usize *ENTRY_BYTES .. (i as usize + 1)*ENTRY_BYTES])?;
+					write(&chunk[i as usize * ENTRY_BYTES..(i as usize + 1) * ENTRY_BYTES])?;
 				}
 			}
 		}
@@ -303,14 +324,8 @@ pub struct LogWriter<'a> {
 }
 
 impl<'a> LogWriter<'a> {
-	pub fn new(
-		overlays: &'a RwLock<LogOverlays>,
-		record_id: u64,
-	) -> LogWriter<'a> {
-		LogWriter {
-			overlays,
-			log: LogChange::new(record_id),
-		}
+	pub fn new(overlays: &'a RwLock<LogOverlays>, record_id: u64) -> LogWriter<'a> {
+		LogWriter { overlays, log: LogChange::new(record_id) }
 	}
 
 	pub fn record_id(&self) -> u64 {
@@ -321,15 +336,20 @@ impl<'a> LogWriter<'a> {
 		match self.log.local_index.entry(table).or_default().map.entry(index) {
 			std::collections::hash_map::Entry::Occupied(mut entry) => {
 				*entry.get_mut() = (self.log.record_id, entry.get().1 | (1 << sub), *data);
-			}
+			},
 			std::collections::hash_map::Entry::Vacant(entry) => {
 				entry.insert((self.log.record_id, 1 << sub, *data));
-			}
+			},
 		}
 	}
 
 	pub fn insert_value(&mut self, table: ValueTableId, index: u64, data: Vec<u8>) {
-		self.log.local_values.entry(table).or_default().map.insert(index, (self.log.record_id, data));
+		self.log
+			.local_values
+			.entry(table)
+			.or_default()
+			.map
+			.insert(index, (self.log.record_id, data));
 	}
 
 	pub fn drop_table(&mut self, id: IndexTableId) {
@@ -342,15 +362,30 @@ impl<'a> LogWriter<'a> {
 }
 
 impl<'a> LogQuery for LogWriter<'a> {
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R> (&self, table: IndexTableId, index: u64, f: F) -> Option<R> {
-		match self.log.local_index.get(&table).and_then(|o| o.map.get(&index).map(|(_id, _mask, data)| data)) {
+	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
+		&self,
+		table: IndexTableId,
+		index: u64,
+		f: F,
+	) -> Option<R> {
+		match self
+			.log
+			.local_index
+			.get(&table)
+			.and_then(|o| o.map.get(&index).map(|(_id, _mask, data)| data))
+		{
 			Some(data) => Some(f(data)),
 			None => self.overlays.with_index(table, index, f),
 		}
 	}
 
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut[u8]) -> bool {
-		if let Some(d) = self.log.local_values.get(&table).and_then(|o| o.map.get(&index).map(|(_id, data)| data)) {
+	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool {
+		if let Some(d) = self
+			.log
+			.local_values
+			.get(&table)
+			.and_then(|o| o.map.get(&index).map(|(_id, data)| data))
+		{
 			let len = dest.len().min(d.len());
 			dest[0..len].copy_from_slice(&d[0..len]);
 			true
@@ -366,18 +401,42 @@ pub struct IdentityHash(u64);
 pub type BuildIdHash = std::hash::BuildHasherDefault<IdentityHash>;
 
 impl std::hash::Hasher for IdentityHash {
-    fn write(&mut self, _: &[u8]) { unreachable!() }
-    fn write_u8(&mut self, _: u8)       { unreachable!() }
-    fn write_u16(&mut self, _: u16)     { unreachable!() }
-    fn write_u32(&mut self, _: u32)     { unreachable!() }
-    fn write_u64(&mut self, n: u64)     { self.0 = n }
-    fn write_usize(&mut self, _: usize) { unreachable!() }
-    fn write_i8(&mut self, _: i8)       { unreachable!() }
-    fn write_i16(&mut self, _: i16)     { unreachable!() }
-    fn write_i32(&mut self, _: i32)     { unreachable!() }
-    fn write_i64(&mut self, _: i64)     { unreachable!() }
-    fn write_isize(&mut self, _: isize) { unreachable!() }
-    fn finish(&self) -> u64 { self.0 }
+	fn write(&mut self, _: &[u8]) {
+		unreachable!()
+	}
+	fn write_u8(&mut self, _: u8) {
+		unreachable!()
+	}
+	fn write_u16(&mut self, _: u16) {
+		unreachable!()
+	}
+	fn write_u32(&mut self, _: u32) {
+		unreachable!()
+	}
+	fn write_u64(&mut self, n: u64) {
+		self.0 = n
+	}
+	fn write_usize(&mut self, _: usize) {
+		unreachable!()
+	}
+	fn write_i8(&mut self, _: i8) {
+		unreachable!()
+	}
+	fn write_i16(&mut self, _: i16) {
+		unreachable!()
+	}
+	fn write_i32(&mut self, _: i32) {
+		unreachable!()
+	}
+	fn write_i64(&mut self, _: i64) {
+		unreachable!()
+	}
+	fn write_isize(&mut self, _: isize) {
+		unreachable!()
+	}
+	fn finish(&self) -> u64 {
+		self.0
+	}
 }
 
 #[derive(Default)]
@@ -457,7 +516,7 @@ impl Log {
 				}
 			}
 		}
-		logs.make_contiguous().sort_by_key(|(_id, record_id,  _)| *record_id);
+		logs.make_contiguous().sort_by_key(|(_id, record_id, _)| *record_id);
 		let next_log_id = if logs.is_empty() { 0 } else { max_log_id + 1 };
 
 		Ok(Log {
@@ -491,7 +550,7 @@ impl Log {
 	pub fn open_log_file(path: &std::path::Path) -> Result<(std::fs::File, Option<u64>)> {
 		let mut file = std::fs::OpenOptions::new().read(true).write(true).open(path)?;
 		if file.metadata()?.len() == 0 {
-			return Ok((file, None));
+			return Ok((file, None))
 		}
 		// read first record id
 		let mut buf = [0; 9];
@@ -536,7 +595,7 @@ impl Log {
 
 	pub fn begin_record(&self) -> LogWriter<'_> {
 		let id = self.next_record_id.fetch_add(1, Ordering::Relaxed);
-		LogWriter::new( &self.overlays, id)
+		LogWriter::new(&self.overlays, id)
 	}
 
 	pub fn end_record(&self, log: LogChange) -> Result<u64> {
@@ -552,15 +611,12 @@ impl Log {
 				// find a free id
 				let id = self.next_log_id.fetch_add(1, Ordering::SeqCst);
 				let path = Self::log_path(&self.path, id);
-				let file = std::fs::OpenOptions::new().create(true).read(true).write(true).open(path)?;
+				let file =
+					std::fs::OpenOptions::new().create(true).read(true).write(true).open(path)?;
 				log::debug!(target: "parity-db", "Flush: Activated new writer {}", id);
 				(id, file)
 			};
-			*appending = Some(Appending {
-				size: 0,
-				file: std::io::BufWriter::new(file),
-				id,
-			});
+			*appending = Some(Appending { size: 0, file: std::io::BufWriter::new(file), id });
 		}
 		let appending = appending.as_mut().unwrap();
 		let (index, values, bytes) = log.to_file(&mut appending.file)?;
@@ -597,18 +653,18 @@ impl Log {
 		for (table, index) in cleared.index.into_iter() {
 			if let Some(ref mut overlay) = overlays.index.get_mut(&table) {
 				if let std::collections::hash_map::Entry::Occupied(e) = overlay.map.entry(index) {
-                    if e.get().0 == record_id {
-                        e.remove_entry();
-                    }
-    			}
+					if e.get().0 == record_id {
+						e.remove_entry();
+					}
+				}
 			}
 		}
 		for (table, index) in cleared.values.into_iter() {
 			if let Some(ref mut overlay) = overlays.value.get_mut(&table) {
 				if let std::collections::hash_map::Entry::Occupied(e) = overlay.map.entry(index) {
-                    if e.get().0 == record_id {
-                        e.remove_entry();
-                    }
+					if e.get().0 == record_id {
+						e.remove_entry();
+					}
 				}
 			}
 		}
@@ -624,7 +680,7 @@ impl Log {
 		if flushing.is_some() {
 			let mut reading_state = self.reading_state.lock();
 
-			while *reading_state == ReadingState::Reading  {
+			while *reading_state == ReadingState::Reading {
 				log::debug!(target: "parity-db", "Flush: Awaiting log reader");
 				self.done_reading_cv.wait(&mut reading_state)
 			}
@@ -688,10 +744,7 @@ impl Log {
 		}
 		if let Some((id, _record_id, file)) = self.replay_queue.write().pop_front() {
 			log::debug!(target: "parity-db", "Replay: Activated log reader {}", id);
-			*reading = Some(Reading {
-				id,
-				file: std::io::BufReader::new(file),
-			});
+			*reading = Some(Reading { id, file: std::io::BufReader::new(file) });
 			*self.reading_state.lock() = ReadingState::Reading;
 			Ok(Some(id))
 		} else {
@@ -701,9 +754,7 @@ impl Log {
 	}
 
 	pub fn clean_logs(&self, count: usize) -> Result<bool> {
-		let mut cleaned: Vec<_> = {
-			self.cleanup_queue.write().drain(0..count).collect()
-		};
+		let mut cleaned: Vec<_> = { self.cleanup_queue.write().drain(0..count).collect() };
 		for (id, ref mut file) in cleaned.iter_mut() {
 			log::debug!(target: "parity-db", "Cleaned: {}", id);
 			file.seek(std::io::SeekFrom::Start(0))?;
@@ -732,27 +783,25 @@ impl Log {
 		let mut reading_state = self.reading_state.lock();
 		if *reading_state != ReadingState::Reading {
 			log::trace!(target: "parity-db", "No logs to enact");
-			return Ok(None);
+			return Ok(None)
 		}
 
 		let reading = self.reading.write();
 		if reading.is_none() {
 			log::trace!(target: "parity-db", "No active reader");
-			return Ok(None);
+			return Ok(None)
 		}
 		let reading = RwLockWriteGuard::map(reading, |r| &mut r.as_mut().unwrap().file);
 		let mut reader = LogReader::new(reading, validate);
 		match reader.next() {
-			Ok(LogAction::BeginRecord) => {
-				Ok(Some(reader))
-			}
+			Ok(LogAction::BeginRecord) => Ok(Some(reader)),
 			Ok(_) => Err(Error::Corruption("Bad log record structure".into())),
 			Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
 				*reading_state = ReadingState::Idle;
 				self.done_reading_cv.notify_one();
 				log::debug!(target: "parity-db", "Read: End of log");
 				Ok(None)
-			}
+			},
 			Err(e) => Err(e),
 		}
 	}

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -14,11 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::{
+	column::{ColId, IterState},
+	db::{CommitChangeSet, Db, IndexedChangeSet},
+	options::Options,
+	Error, Result,
+};
 /// Database migration.
-
 use std::path::Path;
-use crate::{options::Options, db::Db, Error, Result, column::{ColId, IterState}};
-use crate::db::{CommitChangeSet, IndexedChangeSet};
 
 const COMMIT_SIZE: usize = 10240;
 const OVERWRITE_TMP_PATH: &str = "to_revert_overwrite";
@@ -32,20 +35,20 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 		to_migrate.insert(*force);
 	}
 	if source_meta.columns.len() != to.columns.len() {
-		return Err(Error::Migration("Source and dest columns mismatch".into()));
+		return Err(Error::Migration("Source and dest columns mismatch".into()))
 	}
 
 	// Make sure we are using the same salt value.
 	to.salt = Some(source_meta.salt);
 
 	if (to.salt.is_none()) && overwrite {
-		return Err(Error::Migration("Changing salt need to update metadata at once.".into()));
+		return Err(Error::Migration("Changing salt need to update metadata at once.".into()))
 	}
 
 	let mut source_options = Options::with_columns(from, source_meta.columns.len() as u8);
 	source_options.salt = Some(source_meta.salt);
 	source_options.columns = source_meta.columns;
-	
+
 	let mut source = Db::open(&source_options)?;
 	let mut dest = Db::open_or_create(&to)?;
 
@@ -53,34 +56,37 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 	let mut commit = CommitChangeSet::default();
 	let mut nb_commit = 0;
 	let mut last_time = std::time::Instant::now();
-	for c in 0 .. source_options.columns.len() as ColId {
+	for c in 0..source_options.columns.len() as ColId {
 		if source_options.columns[c as usize] != to.columns[c as usize] {
 			to_migrate.insert(c);
 		}
 	}
-	for c in 0 .. source_options.columns.len() as ColId {
+	for c in 0..source_options.columns.len() as ColId {
 		if !to_migrate.contains(&c) {
 			if !overwrite {
 				std::mem::drop(dest);
 				copy_column(c, from, &to.path)?;
 				dest = Db::open_or_create(&to)?;
 			}
-			continue;
+			continue
 		}
 		log::info!("Migrating col {}", c);
 		source.iter_column_while(c, |IterState { chunk_index: index, key, rc, mut value }| {
 			//TODO: more efficient ref migration
-			for _ in 0 .. rc {
+			for _ in 0..rc {
 				let value = std::mem::take(&mut value);
-				commit.indexed.entry(c)
+				commit
+					.indexed
+					.entry(c)
 					.or_insert_with(|| IndexedChangeSet::new(c))
-					.changes.push((key, Some(value)));
+					.changes
+					.push((key, Some(value)));
 				nb_commit += 1;
 				if nb_commit == COMMIT_SIZE {
 					ncommits += 1;
 					if let Err(e) = dest.commit_raw(std::mem::take(&mut commit)) {
 						log::warn!("Migration error: {:?}", e);
-						return false;
+						return false
 					}
 					nb_commit = 0;
 
@@ -106,21 +112,29 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 			tmp_dir.push(OVERWRITE_TMP_PATH);
 			let remove_tmp_dir = || -> Result<()> {
 				if std::fs::metadata(&tmp_dir).is_ok() {
-					std::fs::remove_dir_all(&tmp_dir)
-						.map_err(|e| Error::Migration(format!("Error removing overwrite tmp dir: {:?}", e)))?;
+					std::fs::remove_dir_all(&tmp_dir).map_err(|e| {
+						Error::Migration(format!("Error removing overwrite tmp dir: {:?}", e))
+					})?;
 				}
 				Ok(())
 			};
 			remove_tmp_dir()?;
-			std::fs::create_dir_all(&tmp_dir)
-				.map_err(|e| Error::Migration(format!("Error creating overwrite tmp dir: {:?}", e)))?;
+			std::fs::create_dir_all(&tmp_dir).map_err(|e| {
+				Error::Migration(format!("Error creating overwrite tmp dir: {:?}", e))
+			})?;
 
 			move_column(c, from, &tmp_dir)?;
 			move_column(c, &to.path, from)?;
 			source_options.columns[c as usize] = to.columns[c as usize].clone();
-			source_options.write_metadata(from, &to.salt.expect("Migrate requires salt"))
-				.map_err(|e| Error::Migration(format!("Error {:?}\nFail updating metadata of column {:?} \
-							in source, please restore manually before restarting.", e, c)))?;
+			source_options
+				.write_metadata(from, &to.salt.expect("Migrate requires salt"))
+				.map_err(|e| {
+					Error::Migration(format!(
+						"Error {:?}\nFail updating metadata of column {:?} \
+							in source, please restore manually before restarting.",
+						e, c
+					))
+				})?;
 			remove_tmp_dir()?;
 			source = Db::open(&source_options)?;
 			dest = Db::open_or_create(&to)?;
@@ -144,9 +158,9 @@ fn deplace_column(c: ColId, from: &Path, to: &Path, copy: bool) -> Result<()> {
 	for entry in std::fs::read_dir(from)? {
 		let entry = entry?;
 		if let Some(file) = entry.path().file_name().and_then(|f| f.to_str()) {
-			if crate::index::TableId::is_file_name(c, file)
-				|| crate::table::TableId::is_file_name(c, file) {
-
+			if crate::index::TableId::is_file_name(c, file) ||
+				crate::table::TableId::is_file_name(c, file)
+			{
 				let mut from = from.to_path_buf();
 				from.push(file);
 				let mut to = to.to_path_buf();
@@ -164,7 +178,7 @@ fn deplace_column(c: ColId, from: &Path, to: &Path, copy: bool) -> Result<()> {
 
 #[cfg(test)]
 mod test {
-	use crate::{Db, Options, migration::migrate};
+	use crate::{migration::migrate, Db, Options};
 
 	struct TempDir(std::path::PathBuf);
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -23,7 +23,7 @@ use crate::db::{CommitChangeSet, IndexedChangeSet};
 const COMMIT_SIZE: usize = 10240;
 const OVERWRITE_TMP_PATH: &str = "to_revert_overwrite";
 
-pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &Vec<u8>) -> Result<()> {
+pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u8]) -> Result<()> {
 	let source_meta = Options::load_metadata(from)?
 		.ok_or_else(|| Error::Migration("Error loading source metadata".into()))?;
 
@@ -115,7 +115,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &Ve
 			std::fs::create_dir_all(&tmp_dir)
 				.map_err(|e| Error::Migration(format!("Error creating overwrite tmp dir: {:?}", e)))?;
 
-			move_column(c, &from, &tmp_dir)?;
+			move_column(c, from, &tmp_dir)?;
 			move_column(c, &to.path, from)?;
 			source_options.columns[c as usize] = to.columns[c as usize].clone();
 			source_options.write_metadata(from, &to.salt.expect("Migrate requires salt"))

--- a/src/options.rs
+++ b/src/options.rs
@@ -180,7 +180,7 @@ impl Options {
 			}
 			Ok(meta)
 		} else if create {
-			let s: Salt = self.salt.unwrap_or(rand::thread_rng().gen());
+			let s: Salt = self.salt.unwrap_or_else(||rand::thread_rng().gen());
 			self.write_metadata(&self.path, &s)?;
 			Ok(Metadata {
 				version: CURRENT_VERSION,
@@ -211,9 +211,9 @@ impl Options {
 		let mut version = 0;
 		for l in file.lines() {
 			let l = l?;
-			let mut vals = l.split("=");
-			let k = vals.next().ok_or(Error::Corruption("Bad metadata".into()))?;
-			let v = vals.next().ok_or(Error::Corruption("Bad metadata".into()))?;
+			let mut vals = l.split('=');
+			let k = vals.next().ok_or_else(||Error::Corruption("Bad metadata".into()))?;
+			let v = vals.next().ok_or_else(||Error::Corruption("Bad metadata".into()))?;
 			if k == "version" {
 				version = u32::from_str(v).map_err(|_| Error::Corruption("Bad version string".into()))?;
 			} else if k == "salt" {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -14,19 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::{column::ColId, error::Result, table::SIZE_TIERS};
 /// Database statistics.
-
-use std::sync::atomic::{AtomicU64, AtomicU32, AtomicI64, Ordering};
-use std::mem::MaybeUninit;
-use std::io::{Read, Write, Cursor};
-use crate::{error::Result, column::ColId, table::SIZE_TIERS};
+use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
+use std::{
+	io::{Cursor, Read, Write},
+	mem::MaybeUninit,
+};
 
 // store up to value of size HISTOGRAM_BUCKETS * 2 ^ HISTOGRAM_BUCKET_BITS,
 // that is 32ko
 const HISTOGRAM_BUCKETS: usize = 1024;
 const HISTOGRAM_BUCKET_BITS: u8 = 5;
 
-pub const TOTAL_SIZE: usize = 4 * HISTOGRAM_BUCKETS + 8 * HISTOGRAM_BUCKETS + 8 * SIZE_TIERS + 8 * 11;
+pub const TOTAL_SIZE: usize =
+	4 * HISTOGRAM_BUCKETS + 8 * HISTOGRAM_BUCKETS + 8 * SIZE_TIERS + 8 * 11;
 
 pub struct ColumnStats {
 	value_histogram: [AtomicU32; HISTOGRAM_BUCKETS],
@@ -64,15 +66,21 @@ fn read_i64(cursor: &mut Cursor<&[u8]>) -> AtomicI64 {
 }
 
 fn write_u32(cursor: &mut Cursor<&mut [u8]>, val: &AtomicU32) {
-	cursor.write_all(&val.load(Ordering::Relaxed).to_le_bytes()).expect("Incorrent stats buffer");
+	cursor
+		.write_all(&val.load(Ordering::Relaxed).to_le_bytes())
+		.expect("Incorrent stats buffer");
 }
 
 fn write_u64(cursor: &mut Cursor<&mut [u8]>, val: &AtomicU64) {
-	cursor.write_all(&val.load(Ordering::Relaxed).to_le_bytes()).expect("Incorrent stats buffer");
+	cursor
+		.write_all(&val.load(Ordering::Relaxed).to_le_bytes())
+		.expect("Incorrent stats buffer");
 }
 
 fn write_i64(cursor: &mut Cursor<&mut [u8]>, val: &AtomicI64) {
-	cursor.write_all(&val.load(Ordering::Relaxed).to_le_bytes()).expect("Incorrent stats buffer");
+	cursor
+		.write_all(&val.load(Ordering::Relaxed).to_le_bytes())
+		.expect("Incorrent stats buffer");
 }
 
 fn value_histogram_index(size: u32) -> Option<usize> {
@@ -87,11 +95,13 @@ fn value_histogram_index(size: u32) -> Option<usize> {
 impl ColumnStats {
 	pub fn from_slice(data: &[u8]) -> ColumnStats {
 		let mut cursor = Cursor::new(data);
-		let mut value_histogram: [AtomicU32; HISTOGRAM_BUCKETS] = unsafe { MaybeUninit::uninit().assume_init() };
+		let mut value_histogram: [AtomicU32; HISTOGRAM_BUCKETS] =
+			unsafe { MaybeUninit::uninit().assume_init() };
 		for item in value_histogram.iter_mut() {
 			*item = read_u32(&mut cursor);
 		}
-		let mut query_histogram: [AtomicU64; SIZE_TIERS] = unsafe { MaybeUninit::uninit().assume_init() };
+		let mut query_histogram: [AtomicU64; SIZE_TIERS] =
+			unsafe { MaybeUninit::uninit().assume_init() };
 		for item in query_histogram.iter_mut() {
 			*item = read_u64(&mut cursor);
 		}
@@ -118,8 +128,10 @@ impl ColumnStats {
 	}
 
 	pub fn empty() -> ColumnStats {
-		let value_histogram: [AtomicU32; HISTOGRAM_BUCKETS] = unsafe { std::mem::transmute([0u32; HISTOGRAM_BUCKETS]) };
-		let query_histogram: [AtomicU64; SIZE_TIERS] = unsafe { std::mem::transmute([0u64; SIZE_TIERS]) };
+		let value_histogram: [AtomicU32; HISTOGRAM_BUCKETS] =
+			unsafe { std::mem::transmute([0u32; HISTOGRAM_BUCKETS]) };
+		let query_histogram: [AtomicU64; SIZE_TIERS] =
+			unsafe { std::mem::transmute([0u64; SIZE_TIERS]) };
 		ColumnStats {
 			value_histogram,
 			query_histogram,
@@ -167,19 +179,32 @@ impl ColumnStats {
 		writeln!(writer, "Total values: {}", self.total_values.load(Ordering::Relaxed))?;
 		writeln!(writer, "Total bytes: {}", self.total_bytes.load(Ordering::Relaxed))?;
 		writeln!(writer, "Total oversized values: {}", self.oversized.load(Ordering::Relaxed))?;
-		writeln!(writer, "Total oversized bytes: {}", self.oversized_bytes.load(Ordering::Relaxed))?;
+		writeln!(
+			writer,
+			"Total oversized bytes: {}",
+			self.oversized_bytes.load(Ordering::Relaxed)
+		)?;
 		writeln!(writer, "Total commits: {}", self.commits.load(Ordering::Relaxed))?;
 		writeln!(writer, "New value insertions: {}", self.inserted_new.load(Ordering::Relaxed))?;
-		writeln!(writer, "Existing value insertions: {}", self.inserted_overwrite.load(Ordering::Relaxed))?;
+		writeln!(
+			writer,
+			"Existing value insertions: {}",
+			self.inserted_overwrite.load(Ordering::Relaxed)
+		)?;
 		writeln!(writer, "Removals: {}", self.removed_hit.load(Ordering::Relaxed))?;
 		writeln!(writer, "Missed removals: {}", self.removed_miss.load(Ordering::Relaxed))?;
-		writeln!(writer, "Uncompressed bytes: {}", self.uncompressed_bytes.load(Ordering::Relaxed))?;
+		writeln!(
+			writer,
+			"Uncompressed bytes: {}",
+			self.uncompressed_bytes.load(Ordering::Relaxed)
+		)?;
 		writeln!(writer, "Compression deltas:")?;
-		for i in 0 .. HISTOGRAM_BUCKETS {
+		for i in 0..HISTOGRAM_BUCKETS {
 			let count = self.value_histogram[i].load(Ordering::Relaxed);
 			let delta = self.compression_delta[i].load(Ordering::Relaxed);
 			if count != 0 && delta != 0 {
-				writeln!(writer,
+				writeln!(
+					writer,
 					"    {}-{}: {}",
 					i << HISTOGRAM_BUCKET_BITS,
 					(((i + 1) << HISTOGRAM_BUCKET_BITS) - 1),
@@ -188,7 +213,7 @@ impl ColumnStats {
 			}
 		}
 		write!(writer, "Queries per size tier: [")?;
-		for i in 0 .. SIZE_TIERS {
+		for i in 0..SIZE_TIERS {
 			if i == SIZE_TIERS - 1 {
 				writeln!(writer, "{}]", self.query_histogram[i].load(Ordering::Relaxed))?;
 			} else {
@@ -197,10 +222,11 @@ impl ColumnStats {
 		}
 		writeln!(writer, "Missed queries: {}", self.queries_miss.load(Ordering::Relaxed))?;
 		writeln!(writer, "Value histogram:")?;
-		for i in 0 .. HISTOGRAM_BUCKETS {
+		for i in 0..HISTOGRAM_BUCKETS {
 			let count = self.value_histogram[i].load(Ordering::Relaxed);
 			if count != 0 {
-				writeln!(writer,
+				writeln!(
+					writer,
 					"    {}-{}: {}",
 					i << HISTOGRAM_BUCKET_BITS,
 					(((i + 1) << HISTOGRAM_BUCKET_BITS) - 1),
@@ -227,7 +253,8 @@ impl ColumnStats {
 	pub fn insert(&self, size: u32, compressed: u32) {
 		if let Some(index) = value_histogram_index(size) {
 			self.value_histogram[index].fetch_add(1, Ordering::Relaxed);
-			self.compression_delta[index].fetch_add(size as i64 - compressed as i64, Ordering::Relaxed);
+			self.compression_delta[index]
+				.fetch_add(size as i64 - compressed as i64, Ordering::Relaxed);
 		} else {
 			self.oversized.fetch_add(1, Ordering::Relaxed);
 			self.oversized_bytes.fetch_add(compressed as u64, Ordering::Relaxed);
@@ -240,7 +267,8 @@ impl ColumnStats {
 	pub fn remove(&self, size: u32, compressed: u32) {
 		if let Some(index) = value_histogram_index(size) {
 			self.value_histogram[index].fetch_sub(1, Ordering::Relaxed);
-			self.compression_delta[index].fetch_sub(size as i64 - compressed as i64, Ordering::Relaxed);
+			self.compression_delta[index]
+				.fetch_sub(size as i64 - compressed as i64, Ordering::Relaxed);
 		} else {
 			self.oversized.fetch_sub(1, Ordering::Relaxed);
 			self.oversized_bytes.fetch_sub(compressed as u64, Ordering::Relaxed);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -88,11 +88,11 @@ impl ColumnStats {
 	pub fn from_slice(data: &[u8]) -> ColumnStats {
 		let mut cursor = Cursor::new(data);
 		let mut value_histogram: [AtomicU32; HISTOGRAM_BUCKETS] = unsafe { MaybeUninit::uninit().assume_init() };
-		for item in value_histogram.iter_mut().take(HISTOGRAM_BUCKETS) {
+		for item in value_histogram.iter_mut() {
 			*item = read_u32(&mut cursor);
 		}
 		let mut query_histogram: [AtomicU64; SIZE_TIERS] = unsafe { MaybeUninit::uninit().assume_init() };
-		for item in query_histogram.iter_mut().take(SIZE_TIERS) {
+		for item in query_histogram.iter_mut() {
 			*item = read_u64(&mut cursor);
 		}
 		let mut stats = ColumnStats {
@@ -111,8 +111,8 @@ impl ColumnStats {
 			uncompressed_bytes: read_u64(&mut cursor),
 			compression_delta: unsafe { MaybeUninit::uninit().assume_init() },
 		};
-		for n in 0 .. HISTOGRAM_BUCKETS {
-			stats.compression_delta[n] = read_i64(&mut cursor);
+		for item in stats.compression_delta.iter_mut() {
+			*item = read_i64(&mut cursor);
 		}
 		stats
 	}
@@ -140,11 +140,11 @@ impl ColumnStats {
 
 	pub fn to_slice(&self, data: &mut [u8]) {
 		let mut cursor = Cursor::new(data);
-		for n in 0 .. HISTOGRAM_BUCKETS {
-			write_u32(&mut cursor, &self.value_histogram[n]);
+		for item in &self.value_histogram {
+			write_u32(&mut cursor, item);
 		}
-		for n in 0 .. SIZE_TIERS {
-			write_u64(&mut cursor, &self.query_histogram[n]);
+		for item in &self.query_histogram {
+			write_u64(&mut cursor, item);
 		}
 		write_u64(&mut cursor, &self.oversized);
 		write_u64(&mut cursor, &self.oversized_bytes);
@@ -157,8 +157,8 @@ impl ColumnStats {
 		write_u64(&mut cursor, &self.removed_miss);
 		write_u64(&mut cursor, &self.queries_miss);
 		write_u64(&mut cursor, &self.uncompressed_bytes);
-		for n in 0 .. HISTOGRAM_BUCKETS {
-			write_i64(&mut cursor, &self.compression_delta[n]);
+		for item in &self.compression_delta {
+			write_i64(&mut cursor, item);
 		}
 	}
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -881,10 +881,10 @@ impl ValueTable {
 				true
 			}) {
 				Ok((rc, compressed)) => {
-                    if rc > 0 && !f(index, rc, result, compressed) {
-    			        break;
-                    }
-    			},
+					if rc > 0 && !f(index, rc, result, compressed) {
+						break;
+					}
+				},
 				Err(crate::error::Error::InvalidValueData) => (), // ignore, can be external index.
 				Err(e) => return Err(e),
 			}


### PR DESCRIPTION
No offense, I know changing codestyle related things may offend devs. Just pick what seems to make sense to you.

Removing superfluous clones and references do make more sense.

But there are other things that seem to be serious, e.g. the unbound locks like this:

`let _ = Self::trigger_reindex(tables, reindex, self.path.as_path());`
