### PR TITLE
Allow writing db version when writing metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/options.rs
+++ b/src/options.rs
@@ -147,15 +147,44 @@ impl Options {
 		}
 	}
 
+	// TODO on next major version remove in favor of write_metadata_with_version
 	pub fn write_metadata(&self, path: &std::path::Path, salt: &Salt) -> Result<()> {
 		let mut path = path.to_path_buf();
 		path.push("metadata");
 		self.write_metadata_file(&path, salt)
 	}
 
+	// TODO on next major version remove in favor of write_metadata_with_version
 	pub fn write_metadata_file(&self, path: &std::path::Path, salt: &Salt) -> Result<()> {
 		let mut file = std::fs::File::create(path)?;
 		writeln!(file, "version={}", CURRENT_VERSION)?;
+		writeln!(file, "salt={}", hex::encode(salt))?;
+		for i in 0..self.columns.len() {
+			writeln!(file, "col{}={}", i, self.columns[i].as_string())?;
+		}
+		Ok(())
+	}
+
+	pub fn write_metadata_with_version(
+		&self,
+		path: &std::path::Path,
+		salt: &Salt,
+		version: Option<u32>,
+	) -> Result<()> {
+		let mut path = path.to_path_buf();
+		path.push("metadata");
+		self.write_metadata_file_with_version(&path, salt, version)
+	}
+
+	pub fn write_metadata_file_with_version(
+		&self,
+		path: &std::path::Path,
+		salt: &Salt,
+		version: Option<u32>,
+	) -> Result<()> {
+		let version = version.unwrap_or(CURRENT_VERSION);
+		let mut file = std::fs::File::create(path)?;
+		writeln!(file, "version={}", version)?;
 		writeln!(file, "salt={}", hex::encode(salt))?;
 		for i in 0..self.columns.len() {
 			writeln!(file, "col{}={}", i, self.columns[i].as_string())?;


### PR DESCRIPTION
The way we use db_version, we should not change it when trying to upgrade metadata.
This PR adds an utility function and increase minor versioning.
Next I plan to change https://github.com/paritytech/substrate/blob/1bd5d786fda99d5a0c27c339226789ac047ea4ae/client/db/src/utils.rs#L279 to restore version and add some logging when this happen. (following code can also be simply removed but I find convenient that we can support harmless metadata change transparently, might be a bit of a footgun, but short term it is the fastest way to have a non breaking build).