### PR TITLE
Return a clear Error::DatabaseNotFound when database does not exist

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1267,12 +1267,7 @@ mod tests {
 	fn test_db_open_should_fail() {
 		let tmp = tempdir().unwrap();
 		let options = Options::with_columns(tmp.path(), 5);
-		assert!(Db::open(&options).is_err(), "Database does not exist, so it should fail to open");
-		assert!(Db::open(&options)
-			.map(|_| ())
-			.unwrap_err()
-			.to_string()
-			.contains("use open_or_create"));
+		assert!(matches!(Db::open(&options), Err(crate::Error::DatabaseNotFound)));
 	}
 
 	#[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -216,9 +216,7 @@ impl Options {
 			self.write_metadata(&self.path, &s)?;
 			Ok(Metadata { version: CURRENT_VERSION, columns: self.columns.clone(), salt: s })
 		} else {
-			Err(Error::InvalidConfiguration(
-				"Database does not exist. To create a new one, use open_or_create".into(),
-			))
+			Err(Error::DatabaseNotFound)
 		}
 	}
 


### PR DESCRIPTION
This fix is necessary to clearly understand when the database cannot be opened due to its non-existence (without string matching the error message).