### PR TITLE
Fix a potential deadlock with parallel commits.

### DIFF
--- a/admin/src/bench/mod.rs
+++ b/admin/src/bench/mod.rs
@@ -214,7 +214,6 @@ fn writer<D: BenchDb>(
 	let commit_size = COMMIT_SIZE;
 	let mut commit = Vec::with_capacity(commit_size);
 
-
 	loop {
 		let n = COMMITS.fetch_add(1, Ordering::SeqCst);
 		let mut key = n as u64 * COMMIT_SIZE as u64 + offset;
@@ -234,7 +233,7 @@ fn writer<D: BenchDb>(
 		commit.clear();
 
 		if n >= start_commit + args.commits || shutdown.load(Ordering::Relaxed) {
-			break;
+			break
 		}
 	}
 }
@@ -244,8 +243,8 @@ fn reader<D: BenchDb>(
 	pool: Arc<SizePool>,
 	seed: u64,
 	index: u64,
-	shutdown: Arc<AtomicBool>)
-{
+	shutdown: Arc<AtomicBool>,
+) {
 	// Query random keys while writing
 	let mut rng = rand::rngs::SmallRng::seed_from_u64(seed + index);
 	while !shutdown.load(Ordering::Relaxed) {
@@ -261,7 +260,7 @@ fn reader<D: BenchDb>(
 			},
 			None => {
 				QUERIES_MISS.fetch_add(1, Ordering::SeqCst);
-			}
+			},
 		}
 	}
 }

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -60,7 +60,7 @@ pub fn run() -> Result<(), String> {
 	options.sync_wal = !cli.shared().no_sync;
 	options.sync_data = !cli.shared().no_sync;
 	options.stats = cli.shared().with_stats;
-	println!("Options {:?}, {:?}", cli, options);
+	log::debug!("Options: {:?}, {:?}", cli, options);
 	match cli.subcommand {
 		SubCommand::Stats(stat) => {
 			let db = parity_db::Db::open_read_only(&options)

--- a/src/db.rs
+++ b/src/db.rs
@@ -360,7 +360,7 @@ impl DbInner {
 						target: "parity-db",
 						"Waking up commit queue worker",
 					);
-					self.commit_queue_full_cv.notify_one();
+					self.commit_queue_full_cv.notify_all();
 				}
 				Some(commit)
 			} else {
@@ -769,7 +769,7 @@ impl DbInner {
 				*err = Some(Arc::new(e));
 				self.shutdown();
 			}
-			self.commit_queue_full_cv.notify_one();
+			self.commit_queue_full_cv.notify_all();
 		}
 	}
 


### PR DESCRIPTION
If there are multiple threads waiting for the commit queue only one of them would be waken up when the queue is processed.