### PR TITLE
Remove orphan btree node.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.3.13"
+version = "0.3.14"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -322,7 +322,7 @@ impl BTreeTable {
 				node.changed = true;
 			} else {
 				if child.entry_index.is_none() {
-					break;
+					break
 				}
 			}
 		}
@@ -332,7 +332,7 @@ impl BTreeTable {
 				node.changed = true;
 			} else {
 				if separator.separator.is_none() {
-					break;
+					break
 				}
 			}
 		}

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -320,12 +320,20 @@ impl BTreeTable {
 		for child in node.children.as_mut().iter_mut() {
 			if child.moved {
 				node.changed = true;
+			} else {
+				if child.entry_index.is_none() {
+					break;
+				}
 			}
 		}
 
 		for separator in node.separators.as_mut().iter_mut() {
 			if separator.modified {
 				node.changed = true;
+			} else {
+				if separator.separator.is_none() {
+					break;
+				}
 			}
 		}
 

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -426,7 +426,6 @@ impl Node {
 			BTreeTable::write_plan_remove_node(values, log, index)?;
 		}
 		self.write_child(at, left, values, log)?;
-		self.write_child(at_right, right, values, log)?;
 		let has_child = true; // rebalance on parent.
 		self.remove_from(at, has_child, false);
 		Ok(())


### PR DESCRIPTION
Found orphan nodes are created in current btree implementation.
I also added an early exit, but I can remove the commit (does not really change perfs).