### PR TITLE
Add reverse iteration for btree db

### DIFF
--- a/admin/src/bench/mod.rs
+++ b/admin/src/bench/mod.rs
@@ -114,7 +114,7 @@ impl Stress {
 			iter: self.iter.unwrap_or(0),
 			writers: self.writers.unwrap_or(1),
 			commits: self.commits.unwrap_or(100_000),
-			seed: self.seed.clone(),
+			seed: self.seed,
 			append: self.append,
 			archive: self.archive,
 			no_check: self.no_check,
@@ -241,7 +241,7 @@ fn reader(db: Arc<Db>, pool: Arc<SizePool>, seed: u64, index: u64, shutdown: Arc
 fn iter(db: Arc<Db>, shutdown: Arc<AtomicBool>) {
 	loop {
 		let mut iter = db.iter(0).unwrap();
-		while let Some(_) = iter.next().unwrap() {
+		while iter.next().unwrap().is_some() {
 			if shutdown.load(Ordering::Relaxed) {
 				return
 			}
@@ -253,7 +253,7 @@ fn iter(db: Arc<Db>, shutdown: Arc<AtomicBool>) {
 pub fn run_internal(args: Args, db: Db) {
 	let args = Arc::new(args);
 	let shutdown = Arc::new(AtomicBool::new(false));
-	let pool = Arc::new(SizePool::from_histogram(&sizes::KUSAMA_STATE_DISTRIBUTION));
+	let pool = Arc::new(SizePool::from_histogram(sizes::KUSAMA_STATE_DISTRIBUTION));
 	let db = Arc::new(db);
 	let start = std::time::Instant::now();
 

--- a/admin/src/bench/sizes.rs
+++ b/admin/src/bench/sizes.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 /// Kusama value size distribution
-pub const KUSAMA_STATE_DISTRIBUTION: &'static [(u32, u32)] = &[
+pub const KUSAMA_STATE_DISTRIBUTION: &[(u32, u32)] = &[
 	(32, 35),
 	(33, 20035),
 	(34, 5369),

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -29,7 +29,7 @@ pub fn run() -> Result<(), String> {
 
 	let mut builder = Builder::from_default_env();
 	let mut logs = cli.shared().log.clone();
-	if logs.len() == 0 {
+	if logs.is_empty() {
 		logs.push("info".to_string());
 	}
 	builder.parse_filters(logs.as_slice().join(",").as_str());
@@ -66,17 +66,17 @@ pub fn run() -> Result<(), String> {
 			let db = parity_db::Db::open_read_only(&options)
 				.map_err(|e| format!("Invalid db: {:?}", e))?;
 			if stat.clear {
-				db.clear_stats(stat.column.clone());
+				db.clear_stats(stat.column);
 			} else {
 				let mut out = std::io::stdout();
-				db.collect_stats(&mut out, stat.column.clone());
+				db.collect_stats(&mut out, stat.column);
 			}
 		},
 		SubCommand::Migrate(args) => {
 			use parity_db::Options;
 			let dest_meta = Options::load_metadata_file(&args.dest_meta)
 				.map_err(|e| format!("Error loading dest metadata: {:?}", e))?
-				.ok_or_else(|| format!("Error opening dest metadata file"))?;
+				.ok_or_else(|| "Error opening dest metadata file".to_string())?;
 
 			let dest_columns = dest_meta.columns;
 

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -408,7 +408,6 @@ impl BTreeIterState {
 			return Ok(None)
 		}
 
-		dbg!(&self.state);
 		while let Some((ix, ty @ NodeType::Child, node)) = self.state.last_mut() {
 			*ty = NodeType::Separator;
 			match col.with_locked(|btree| node.fetch_child(*ix, btree, log))? {
@@ -477,7 +476,7 @@ impl BTreeIterState {
 		self.fetch_root = false;
 		col.with_locked(|b| {
 			let root = BTree::fetch_root(btree.root_index.unwrap_or(NULL_ADDRESS), b, log)?;
-			Node::seek_to_last(root, b, log, btree.depth, &mut self.state)
+			Node::seek_to_last(root, &mut self.state)
 		})
 	}
 }

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -404,15 +404,11 @@ impl BTreeIterState {
 		col: &BTreeTable,
 		log: &impl LogQuery,
 	) -> Result<Option<(Vec<u8>, Value)>> {
-		if !self.fetch_root && self.state.is_empty() {
+		if self.state.is_empty() {
 			return Ok(None)
 		}
 
-		if self.fetch_root {
-			self.seek_to_last(btree, col, log)?;
-			self.fetch_root = false;
-		}
-
+		dbg!(&self.state);
 		while let Some((ix, ty @ NodeType::Child, node)) = self.state.last_mut() {
 			*ty = NodeType::Separator;
 			match col.with_locked(|btree| node.fetch_child(*ix, btree, log))? {

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -251,7 +251,7 @@ impl BTreeIterState {
 		self.state.clear();
 		let found = col.with_locked(|b| {
 			let root = BTree::fetch_root(btree.root_index.unwrap_or(NULL_ADDRESS), b, log)?;
-			Node::seek(root, key, b, log, btree.depth, &mut self.state)
+			Node::seek(root, key, b, log, btree.depth, &mut self.state, false)
 		})?;
 
 		self.next_separator = true;

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -320,20 +320,16 @@ impl BTreeTable {
 		for child in node.children.as_mut().iter_mut() {
 			if child.moved {
 				node.changed = true;
-			} else {
-				if child.entry_index.is_none() {
-					break
-				}
+			} else if child.entry_index.is_none() {
+				break
 			}
 		}
 
 		for separator in node.separators.as_mut().iter_mut() {
 			if separator.modified {
 				node.changed = true;
-			} else {
-				if separator.separator.is_none() {
-					break
-				}
+			} else if separator.separator.is_none() {
+				break
 			}
 		}
 

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -65,7 +65,7 @@ const HEADER_ADDRESS: Address = {
 };
 const ENTRY_CAPACITY: usize = ORDER * 33 + ORDER * 8 + ORDER_CHILD * 8;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct BTreeHeader {
 	pub root: Address,
 	pub depth: u32,

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -561,6 +561,32 @@ impl Node {
 		Ok(())
 	}
 
+	pub fn seek_to_last(
+		from: Self,
+		values: TablesRef,
+		log: &impl LogQuery,
+		depth: u32,
+		stack: &mut Vec<(usize, NodeType, Self)>,
+	) -> Result<()> {
+		let i = if let Some(i) = from.last_child_index().or_else(|| from.last_separator_index()) {
+			i
+		} else {
+			return Ok(())
+		};
+
+		if depth != 0 {
+			if let Some(child) = from.fetch_child(i, values, log)? {
+				if i > 0 {
+					stack.push((i - 1, NodeType::Separator, from));
+				}
+				return Self::seek_to_last(child, values, log, depth - 1, stack)
+			}
+		}
+
+		stack.push((i, NodeType::Separator, from));
+		Ok(())
+	}
+
 	#[cfg(test)]
 	pub fn is_balanced(
 		&self,

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -580,27 +580,14 @@ impl Node {
 
 	pub fn seek_to_last(
 		from: Self,
-		values: TablesRef,
-		log: &impl LogQuery,
-		depth: u32,
+		_values: TablesRef,
+		_log: &impl LogQuery,
+		_depth: u32,
 		stack: &mut Vec<(usize, NodeType, Self)>,
 	) -> Result<()> {
-		let i = if let Some(i) = from.last_child_index().or_else(|| from.last_separator_index()) {
-			i
-		} else {
-			return Ok(())
-		};
-
-		if depth != 0 {
-			if let Some(child) = from.fetch_child(i, values, log)? {
-				if i > 0 {
-					stack.push((i - 1, NodeType::Separator, from));
-				}
-				return Self::seek_to_last(child, values, log, depth - 1, stack)
-			}
+		if let Some(i) = from.last_child_index().or_else(|| from.last_separator_index()) {
+			stack.push((i, NodeType::Separator, from))
 		}
-
-		stack.push((i, NodeType::Separator, from));
 		Ok(())
 	}
 

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -513,10 +513,13 @@ impl Node {
 			return Ok(true)
 		}
 
-		// If we search from end we point to child which is greater than searched value
-		let i = if from_end { i + 1 } else { i };
-
 		if depth != 0 {
+			if from_end {
+				if let Some(child) = from.fetch_child(i + 1, values, log)? {
+					stack.push((i + 1, from));
+					return Self::seek(child, key, values, log, depth - 1, stack, from_end)
+				}
+			}
 			if let Some(child) = from.fetch_child(i, values, log)? {
 				stack.push((i, from));
 				return Self::seek(child, key, values, log, depth - 1, stack, from_end)

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -560,7 +560,7 @@ impl Node {
 /// Nodes with data loaded in memory.
 /// Nodes get only serialized when flushed in the global overlay
 /// (there we need one entry per record id).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Node {
 	pub(super) separators: [node::Separator; ORDER],
 	pub(super) children: [node::Child; ORDER_CHILD],
@@ -573,19 +573,19 @@ impl Default for Node {
 	}
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct Separator {
 	pub(super) modified: bool,
 	pub(super) separator: Option<SeparatorInner>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SeparatorInner {
 	pub key: Vec<u8>,
 	pub value: Address,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct Child {
 	pub(super) moved: bool,
 	pub(super) entry_index: Option<Address>,

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -578,14 +578,10 @@ impl Node {
 		Ok(())
 	}
 
-	pub fn seek_to_last(
-		from: Self,
-		_values: TablesRef,
-		_log: &impl LogQuery,
-		_depth: u32,
-		stack: &mut Vec<(usize, NodeType, Self)>,
-	) -> Result<()> {
-		if let Some(i) = from.last_child_index().or_else(|| from.last_separator_index()) {
+	pub fn seek_to_last(from: Self, stack: &mut Vec<(usize, NodeType, Self)>) -> Result<()> {
+		if let Some(i) = from.last_child_index() {
+			stack.push((i, NodeType::Child, from))
+		} else if let Some(i) = from.last_separator_index() {
 			stack.push((i, NodeType::Separator, from))
 		}
 		Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -1040,22 +1040,21 @@ impl CommitOverlay {
 		last_key: &Option<Vec<u8>>,
 		from_seek: bool,
 	) -> Option<(Value, Option<Value>)> {
-		if let Some(key) = last_key.as_ref() {
-			let mut iter = self.btree_indexed.range::<Vec<u8>, _>(key..);
-			if let Some((k, (_, v))) = iter.next() {
-				if from_seek || k != key {
-					return Some((k.clone(), v.clone()))
-				}
-			} else {
-				return None
-			}
-			iter.next().map(|(k, (_, v))| (k.clone(), v.clone()))
+		let key = if let Some(key) = last_key.as_ref() {
+			key
 		} else {
-			self.btree_indexed
-				.range::<Vec<u8>, _>(..)
-				.next()
-				.map(|(k, (_, v))| (k.clone(), v.clone()))
+			return self.btree_indexed.iter().next().map(|(k, (_, v))| (k.clone(), v.clone()))
+		};
+
+		let mut iter = self.btree_indexed.range::<Vec<u8>, _>(key..);
+
+		let (k, v) = if let Some((k, (_, v))) = iter.next() { (k, v) } else { return None };
+
+		if from_seek || k != key {
+			return Some((k.clone(), v.clone()))
 		}
+
+		iter.next().map(|(k, (_, v))| (k.clone(), v.clone()))
 	}
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1610,7 +1610,11 @@ mod tests {
 	}
 
 	fn test_indexed_btree_inner_3(db_test: EnableCommitPipelineStages) {
+		use rand::SeedableRng;
+
 		use std::collections::BTreeSet;
+
+		let mut rng = rand::rngs::SmallRng::from_rng(rand::thread_rng()).unwrap();
 
 		let tmp = tempdir().unwrap();
 		let col_nb = 0u8;
@@ -1631,11 +1635,11 @@ mod tests {
 		let mut iter = db.iter(0).unwrap();
 
 		for _ in 0..100 {
-			let at = rand::thread_rng().gen_range(0u64..=1024);
+			let at = rng.gen_range(0u64..=1024);
 			iter.seek(&at.to_be_bytes()).unwrap();
 
-			let at = if rand::random() {
-				let take = rand::thread_rng().gen_range(1..100);
+			let at = if rng.gen() {
+				let take = rng.gen_range(1..100);
 				let got = std::iter::from_fn(|| iter.next().unwrap())
 					.map(|(k, _)| u64::from_be_bytes(k.try_into().unwrap()))
 					.take(take)
@@ -1648,7 +1652,7 @@ mod tests {
 			};
 
 			let at = {
-				let take = rand::thread_rng().gen_range(1..100);
+				let take = rng.gen_range(1..100);
 				let got = std::iter::from_fn(|| iter.prev().unwrap())
 					.map(|(k, _)| u64::from_be_bytes(k.try_into().unwrap()))
 					.take(take)
@@ -1658,7 +1662,7 @@ mod tests {
 				expected.last().copied().unwrap_or(at)
 			};
 
-			let take = rand::thread_rng().gen_range(1..100);
+			let take = rng.gen_range(1..100);
 			let got = std::iter::from_fn(|| iter.next().unwrap())
 				.map(|(k, _)| u64::from_be_bytes(k.try_into().unwrap()))
 				.take(take)
@@ -1667,7 +1671,7 @@ mod tests {
 			assert_eq!(got, expected);
 		}
 
-		let take = rand::thread_rng().gen_range(20..100);
+		let take = rng.gen_range(20..100);
 		iter.seek_to_last().unwrap();
 		let got = std::iter::from_fn(|| iter.prev().unwrap())
 			.map(|(k, _)| u64::from_be_bytes(k.try_into().unwrap()))
@@ -2016,6 +2020,7 @@ mod tests {
 
 		let mut iter_state_rev = end_state.iter().rev();
 		let mut iter = db.iter(col_nb).unwrap();
+		iter.seek_to_last().unwrap();
 		for _ in 0..100 {
 			let next = iter.prev().unwrap();
 			assert_eq!(iter_state_rev.next(), next.as_ref().map(|(k, v)| (k, v)));

--- a/src/db.rs
+++ b/src/db.rs
@@ -1068,7 +1068,7 @@ impl CommitOverlay {
 			return self.btree_indexed.iter().rev().next().map(|(k, (_, v))| (k.clone(), v.clone()))
 		};
 
-		let mut iter = self.btree_indexed.range::<Vec<u8>, _>(..key).rev();
+		let mut iter = self.btree_indexed.range::<Vec<u8>, _>(..=key).rev();
 
 		let (k, v) = if let Some((k, (_, v))) = iter.next() { (k, v) } else { return None };
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1056,6 +1056,28 @@ impl CommitOverlay {
 
 		iter.next().map(|(k, (_, v))| (k.clone(), v.clone()))
 	}
+
+	pub fn btree_prev(
+		&self,
+		last_key: &Option<Vec<u8>>,
+		from_seek: bool,
+	) -> Option<(Value, Option<Value>)> {
+		let key = if let Some(key) = last_key.as_ref() {
+			key
+		} else {
+			return self.btree_indexed.iter().rev().next().map(|(k, (_, v))| (k.clone(), v.clone()))
+		};
+
+		let mut iter = self.btree_indexed.range::<Vec<u8>, _>(..key).rev();
+
+		let (k, v) = if let Some((k, (_, v))) = iter.next() { (k, v) } else { return None };
+
+		if from_seek || k != key {
+			return Some((k.clone(), v.clone()))
+		}
+
+		iter.next().map(|(k, (_, v))| (k.clone(), v.clone()))
+	}
 }
 
 #[derive(Default)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1475,6 +1475,7 @@ mod tests {
 
 		let mut iter = db.iter(col_nb).unwrap();
 		assert_eq!(iter.next().unwrap(), None);
+		assert_eq!(iter.prev().unwrap(), None);
 
 		db.commit(vec![(col_nb, key1.clone(), Some(b"value1".to_vec()))]).unwrap();
 		db_test.run_stages(&db);
@@ -1483,6 +1484,15 @@ mod tests {
 		iter.seek(&[]).unwrap();
 		assert_eq!(iter.next().unwrap(), Some((key1.clone(), b"value1".to_vec())));
 		assert_eq!(iter.next().unwrap(), None);
+
+		iter.seek(&[]).unwrap();
+		assert_eq!(iter.next().unwrap(), Some((key1.clone(), b"value1".to_vec())));
+		assert_eq!(iter.prev().unwrap(), Some((key1.clone(), b"value1".to_vec())));
+		assert_eq!(iter.prev().unwrap(), None);
+
+		iter.seek(&[0xff]).unwrap();
+		assert_eq!(iter.prev().unwrap(), Some((key1.clone(), b"value1".to_vec())));
+		assert_eq!(iter.prev().unwrap(), None);
 
 		db.commit(vec![
 			(col_nb, key1.clone(), None),
@@ -1495,10 +1505,16 @@ mod tests {
 		assert_eq!(db.get(col_nb, &key1).unwrap(), None);
 		assert_eq!(db.get(col_nb, &key2).unwrap(), Some(b"value2".to_vec()));
 		assert_eq!(db.get(col_nb, &key3).unwrap(), Some(b"value3".to_vec()));
+
 		iter.seek(key2.as_slice()).unwrap();
 		assert_eq!(iter.next().unwrap(), Some((key2.clone(), b"value2".to_vec())));
 		assert_eq!(iter.next().unwrap(), Some((key3.clone(), b"value3".to_vec())));
 		assert_eq!(iter.next().unwrap(), None);
+
+		iter.seek(key3.as_slice()).unwrap();
+		assert_eq!(iter.prev().unwrap(), Some((key3.clone(), b"value3".to_vec())));
+		assert_eq!(iter.prev().unwrap(), Some((key2.clone(), b"value2".to_vec())));
+		assert_eq!(iter.prev().unwrap(), None);
 
 		db.commit(vec![
 			(col_nb, key2.clone(), Some(b"value2b".to_vec())),

--- a/src/db.rs
+++ b/src/db.rs
@@ -2016,7 +2016,6 @@ mod tests {
 
 		let mut iter_state_rev = end_state.iter().rev();
 		let mut iter = db.iter(col_nb).unwrap();
-		iter.seek(&[0xff; 4]).unwrap();
 		for _ in 0..100 {
 			let next = iter.prev().unwrap();
 			assert_eq!(iter_state_rev.next(), next.as_ref().map(|(k, v)| (k, v)));

--- a/src/db.rs
+++ b/src/db.rs
@@ -1999,5 +1999,13 @@ mod tests {
 			let iter_next = iter.next().unwrap();
 			assert_eq!(state_next, iter_next.as_ref().map(|(k, v)| (k, v)));
 		}
+
+		let mut iter_state_rev = end_state.iter().rev();
+		let mut iter = db.iter(col_nb).unwrap();
+		iter.seek(&[0xff; 4]).unwrap();
+		for _ in 0..100 {
+			let next = iter.prev().unwrap();
+			assert_eq!(iter_state_rev.next(), next.as_ref().map(|(k, v)| (k, v)));
+		}
 	}
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -95,7 +95,7 @@ impl Entry {
 	}
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 pub struct Address(u64);
 
 impl Address {

--- a/src/index.rs
+++ b/src/index.rs
@@ -542,7 +542,7 @@ mod test {
 	fn test_entries() {
 		let mut chunk = IndexTable::transmute_chunk(EMPTY_CHUNK);
 		let mut chunk2 = EMPTY_CHUNK;
-		for i in 0..CHUNK_ENTRIES {
+		for (i, chunk) in chunk.iter_mut().enumerate().take(CHUNK_ENTRIES) {
 			use std::{
 				collections::hash_map::DefaultHasher,
 				hash::{Hash, Hasher},
@@ -552,7 +552,7 @@ mod test {
 			let hash = hasher.finish();
 			let entry = Entry::from_u64(hash as u64);
 			IndexTable::write_entry(&entry, i, &mut chunk2);
-			chunk[i] = entry;
+			*chunk = entry;
 		}
 
 		assert!(IndexTable::transmute_chunk(chunk2) == chunk);

--- a/src/table.rs
+++ b/src/table.rs
@@ -1174,16 +1174,13 @@ mod test {
 
 	fn value(size: usize) -> Value {
 		use rand::RngCore;
-		let mut result = Vec::with_capacity(size);
-		result.resize(size, 0);
+		let mut result = vec![0; size];
 		rand::thread_rng().fill_bytes(&mut result);
 		result
 	}
 
 	fn rc_options() -> ColumnOptions {
-		let mut result = ColumnOptions::default();
-		result.ref_counted = true;
-		result
+		ColumnOptions { ref_counted: true, ..Default::default() }
 	}
 
 	#[test]


### PR DESCRIPTION
This pr adds possibility to go back with btree iterator.

Reviewing by commits would make more sense, as the first two ones are minor refactoring. The rest of commits propagate reverse iterator from bottom to the top.

There are some minor problems with this code though. It repeats itself a lot, because I started of with just negating invariants of `next` function. Also, there is clearly not enough of tests for that, will add them soon.