### PR TITLE
Increment Rc and Change enum

### DIFF
--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -20,10 +20,10 @@ use super::*;
 use crate::{
 	btree::BTreeTable,
 	column::Column,
-	db::{Change, InputChange},
 	error::Result,
 	log::{LogQuery, LogWriter},
 	table::key::TableKeyQuery,
+	Change,
 };
 
 pub struct BTree {
@@ -47,7 +47,7 @@ impl BTree {
 
 	pub fn write_sorted_changes(
 		&mut self,
-		mut changes: &[InputChange],
+		mut changes: &[Change<Vec<u8>, Vec<u8>>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<()> {

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -20,6 +20,7 @@ use super::*;
 use crate::{
 	btree::BTreeTable,
 	column::Column,
+	db::{Change, InputChange},
 	error::Result,
 	log::{LogQuery, LogWriter},
 	table::key::TableKeyQuery,
@@ -46,7 +47,7 @@ impl BTree {
 
 	pub fn write_sorted_changes(
 		&mut self,
-		mut changes: &[(Vec<u8>, Option<Vec<u8>>)],
+		mut changes: &[InputChange],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<()> {

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -23,7 +23,7 @@ use crate::{
 	error::Result,
 	log::{LogQuery, LogWriter},
 	table::key::TableKeyQuery,
-	Change,
+	Operation,
 };
 
 pub struct BTree {
@@ -47,7 +47,7 @@ impl BTree {
 
 	pub fn write_sorted_changes(
 		&mut self,
-		mut changes: &[Change<Vec<u8>, Vec<u8>>],
+		mut changes: &[Operation<Vec<u8>, Vec<u8>>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<()> {

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -432,11 +432,14 @@ pub mod commit_overlay {
 							overlay.insert(key.clone(), (record_id, None));
 						}
 					},
-					Change::IncRc(..) | Change::DecRc(..) => {
+					Change::IncRc(..) => {
 						// Don't add (we allow remove value in overlay when using rc: some
 						// indexing on top of it is expected).
 						if !ref_counted {
-							return Err(Error::InvalidInput(format!("No Rc for column {}", self.col)))
+							return Err(Error::InvalidInput(format!(
+								"No Rc for column {}",
+								self.col
+							)))
 						}
 					},
 				}

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -455,8 +455,6 @@ pub mod commit_overlay {
 				Change::IncRc(..) | Change::DecRc(..) => {
 					// Don't add (we allow remove value in overlay when using rc: some
 					// indexing on top of it is expected).
-					// TODO consider a strict Rc (rather the overhead on DecRc so very
-					// questionable).
 					if !ref_counted {
 						return Err(Error::InvalidInput(format!("No Rc for column {}", col)))
 					}
@@ -493,8 +491,7 @@ pub mod commit_overlay {
 				BTreeHeader { root: tree.root_index.unwrap_or(NULL_ADDRESS), depth: tree.depth };
 			let old_btree_header = btree_header.clone();
 
-			// TODO impl Ord and just use sort
-			self.changes.sort_by_key(|change| change.key().to_vec());
+			self.changes.sort();
 			tree.write_sorted_changes(self.changes.as_slice(), locked, writer)?;
 			*ops += self.changes.len() as u64;
 			BTreeTable::write_plan(locked, &mut tree, writer, record_id, &mut btree_header)?;

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -363,7 +363,7 @@ impl BTreeTable {
 		tables.compression = &crate::compress::NO_COMPRESSION;
 		let result = Ok(if let Some(existing) = node_id {
 			let k = TableKey::NoHash;
-			if let (_, Some(new_index), _) = Column::write_existing_value_plan(
+			if let (_, Some(new_index)) = Column::write_existing_value_plan(
 				&k,
 				tables,
 				existing,

--- a/src/column.rs
+++ b/src/column.rs
@@ -492,6 +492,9 @@ impl HashColumn {
 				},
 				Operation::Reference(key) => {
 					log::trace!(target: "parity-db", "{}: Ignoring increase rc, missing key {}", tables.index.id, hex(key));
+					if self.collect_stats {
+						self.stats.reference_increase_miss();
+					}
 					Ok(PlanOutcome::Skipped)
 				},
 			}
@@ -911,6 +914,9 @@ impl Column {
 				if tables.ref_counted {
 					log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 					tables.tables[tier].write_inc_ref(address.offset(), log)?;
+					if let Some(stats) = stats {
+						stats.reference_increase();
+					}
 					return Ok((Some(PlanOutcome::Written), None))
 				} else {
 					return Ok((Some(PlanOutcome::Skipped), None))

--- a/src/column.rs
+++ b/src/column.rs
@@ -917,7 +917,6 @@ impl Column {
 				},
 			Change::DecRc(_) =>
 				if tables.ref_counted {
-					// TODO this should be part of write_dec_ref?
 					let cur_size = if stats.is_some() { Some(fetch_size()?) } else { None };
 					log::trace!(target: "parity-db", "{}: Decrement ref {}", tables.col, key);
 					let removed = !tables.tables[tier].write_dec_ref(address.offset(), log)?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1115,6 +1115,7 @@ impl CommitOverlay {
 	}
 }
 
+#[derive(PartialEq, Eq)]
 pub enum Change<Key, Value> {
 	SetValue(Key, Value),
 	RemoveValue(Key),
@@ -1122,6 +1123,18 @@ pub enum Change<Key, Value> {
 	DecRc(Key), /* TODO remove ? (same as RemoveValue) -> could have different semantic:
 	             * remove value forcing removal (at least pushing in commit
 	             * overlay) and decrc not touching commit overlay. */
+}
+
+impl<Key: Ord, Value: Eq> PartialOrd<Self> for Change<Key, Value> {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl<Key: Ord, Value: Eq> Ord for Change<Key, Value> {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		self.key().cmp(other.key())
+	}
 }
 
 impl<Key, Value> Change<Key, Value> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1237,8 +1237,6 @@ impl IndexedChangeSet {
 				Change::IncRc(..) | Change::DecRc(..) => {
 					// Don't add (we allow remove value in overlay when using rc: some
 					// indexing on top of it is expected).
-					// TODO consider a strict Rc (rather the overhead on DecRc so very
-					// questionable).
 					if !ref_counted {
 						return Err(Error::InvalidInput(format!("No Rc for column {}", self.col)))
 					}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod table;
 
 pub use btree::BTreeIterator;
 pub use compress::CompressionType;
-pub use db::{check::CheckOptions, Change, Db, InputChange, Value};
+pub use db::{check::CheckOptions, Change, Db, Value};
 pub use error::{Error, Result};
 pub use migration::{clear_column, migrate};
 pub use options::{ColumnOptions, Options};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod table;
 
 pub use btree::BTreeIterator;
 pub use compress::CompressionType;
-pub use db::{check::CheckOptions, Db, Value};
+pub use db::{check::CheckOptions, Change, Db, InputChange, Value};
 pub use error::{Error, Result};
 pub use migration::{clear_column, migrate};
 pub use options::{ColumnOptions, Options};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod table;
 
 pub use btree::BTreeIterator;
 pub use compress::CompressionType;
-pub use db::{check::CheckOptions, Change, Db, Value};
+pub use db::{check::CheckOptions, Db, Operation, Value};
 pub use error::{Error, Result};
 pub use migration::{clear_column, migrate};
 pub use options::{ColumnOptions, Options};

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	column::{ColId, IterState},
-	db::{CommitChangeSet, Db, IndexedChangeSet},
+	db::{Change, CommitChangeSet, Db, IndexedChangeSet},
 	options::Options,
 	Error, Result,
 };
@@ -97,7 +97,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 					.entry(c)
 					.or_insert_with(|| IndexedChangeSet::new(c))
 					.changes
-					.push((key, Some(value)));
+					.push(Change::SetValue(key, value));
 				nb_commit += 1;
 				if nb_commit == COMMIT_SIZE {
 					ncommits += 1;

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	column::{ColId, IterState},
-	db::{Change, CommitChangeSet, Db, IndexedChangeSet},
+	db::{CommitChangeSet, Db, IndexedChangeSet, Operation},
 	options::Options,
 	Error, Result,
 };
@@ -97,7 +97,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 					.entry(c)
 					.or_insert_with(|| IndexedChangeSet::new(c))
 					.changes
-					.push(Change::SetValue(key, value));
+					.push(Operation::Set(key, value));
 				nb_commit += 1;
 				if nb_commit == COMMIT_SIZE {
 					ncommits += 1;

--- a/src/options.rs
+++ b/src/options.rs
@@ -57,6 +57,9 @@ pub struct ColumnOptions {
 	/// Allows for skipping additional key hashing.
 	pub uniform: bool,
 	/// Use reference counting for values.
+	///
+	/// Reference counting do not enforce immediate removal
+	/// and user should not check for missing value.
 	pub ref_counted: bool,
 	/// Compression to use for this column.
 	pub compression: CompressionType,


### PR DESCRIPTION
I did get some code from old branch to propose this PR.

It expose a new operand to commit: `IncRc` that allow increase rc count in columns using rc, but without knowing the value.

This is not very important feature (can be use at one place in chain storage of substrate).

The PR also define a named enum `Change` that could be extended with different operand (I did have this in multiple branch so it make sense for me to have it).