### PR TITLE
Moves IdentityHash out of lib.rs

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,7 @@ use crate::{
 	btree::{commit_overlay::BTreeChangeSet, BTreeIterator, BTreeTable},
 	column::{hash_key, ColId, Column, IterState, ReindexBatch},
 	error::{Error, Result},
+	hash::IdentityBuildHasher,
 	index::PlanOutcome,
 	log::{Log, LogAction},
 	options::Options,
@@ -1029,7 +1030,7 @@ impl Drop for Db {
 	}
 }
 
-pub type IndexedCommitOverlay = HashMap<Key, (u64, Option<Value>), crate::IdentityBuildHasher>;
+pub type IndexedCommitOverlay = HashMap<Key, (u64, Option<Value>), IdentityBuildHasher>;
 pub type BTreeCommitOverlay = BTreeMap<Vec<u8>, (u64, Option<Value>)>;
 
 #[derive(Debug)]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,18 @@
+// Copyright 2021-2022 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or MIT.
+
+use std::hash::BuildHasherDefault;
+
+#[derive(Default)]
+pub struct IdentityKeyHash(u64);
+pub type IdentityBuildHasher = BuildHasherDefault<IdentityKeyHash>;
+
+impl std::hash::Hasher for IdentityKeyHash {
+	fn finish(&self) -> u64 {
+		self.0
+	}
+
+	fn write(&mut self, bytes: &[u8]) {
+		self.0 = u64::from_le_bytes((&bytes[0..8]).try_into().unwrap())
+	}
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,6 @@
 
 use crate::{
 	column::ColId,
-	const_assert,
 	display::hex,
 	error::{Error, Result},
 	log::{LogQuery, LogReader, LogWriter},
@@ -27,7 +26,8 @@ const EMPTY_CHUNK: Chunk = [0u8; CHUNK_LEN];
 
 pub type Chunk = [u8; CHUNK_LEN];
 
-const_assert!(META_SIZE >= HEADER_SIZE + stats::TOTAL_SIZE);
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(META_SIZE >= HEADER_SIZE + stats::TOTAL_SIZE);
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct Entry(u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod db;
 mod display;
 mod error;
 mod file;
+mod hash;
 mod index;
 mod log;
 mod migration;
@@ -23,59 +24,5 @@ pub use migration::{clear_column, migrate};
 pub use options::{ColumnOptions, Options};
 pub use stats::{ColumnStatSummary, StatSummary};
 
-#[derive(Default)]
-pub struct IdentityKeyHash(u64);
-type IdentityBuildHasher = std::hash::BuildHasherDefault<IdentityKeyHash>;
-
-impl std::hash::Hasher for IdentityKeyHash {
-	fn write(&mut self, bytes: &[u8]) {
-		self.0 = u64::from_le_bytes((&bytes[0..8]).try_into().unwrap())
-	}
-	fn write_u8(&mut self, _: u8) {
-		unreachable!()
-	}
-	fn write_u16(&mut self, _: u16) {
-		unreachable!()
-	}
-	fn write_u32(&mut self, _: u32) {
-		unreachable!()
-	}
-	fn write_u64(&mut self, _: u64) {
-		unreachable!()
-	}
-	fn write_usize(&mut self, _: usize) {}
-	fn write_i8(&mut self, _: i8) {
-		unreachable!()
-	}
-	fn write_i16(&mut self, _: i16) {
-		unreachable!()
-	}
-	fn write_i32(&mut self, _: i32) {
-		unreachable!()
-	}
-	fn write_i64(&mut self, _: i64) {
-		unreachable!()
-	}
-	fn write_isize(&mut self, _: isize) {
-		unreachable!()
-	}
-	fn finish(&self) -> u64 {
-		self.0
-	}
-}
-
 pub const KEY_SIZE: usize = 32;
 pub type Key = [u8; KEY_SIZE];
-
-#[macro_export]
-macro_rules! const_assert {
-	(let $e:expr; ) => (
-		const _: [(); { const ASSERT: bool = $e; ASSERT} as usize -1] = [];
-	);
-	(let $e:expr; $e1:expr $(, $ee:expr)*) => (
-		const_assert!(let ($e) && ($e1); $($ee),*);
-	);
-	($e:expr $(, $ee:expr)*) => (
-		const_assert!(let true && ($e); $($ee),*);
-	);
-}


### PR DESCRIPTION
Simplifies the lib.rs file

Inlines the const_assert macro that is only used once