### PR TITLE
Applies some IntelliJ lint suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,10 +18,8 @@ indent_size=2
 indent_style=space
 indent_size=2
 tab_width=8
-end_of_line=lf
 
 [*.sh]
 indent_style=space
 indent_size=2
 tab_width=8
-end_of_line=lf

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The database is a universal key-value storage that supports transactions. The AP
 Database supports multiple concurrent readers. All writes are serialized. Writes are performed in batches, also known as transactions. Transactions are applied atomically. Either all of the transaction data is written, or none. Queries can't retrieve partially committed data.
 
 ### No cache
-Database does implement any custom data caching. Instead it relies on OS page cache. Performance of a large database therefore depends on how much system memory is available to be used in OS page cache.
+Database does implement any custom data caching. Instead, it relies on OS page cache. Performance of a large database therefore depends on how much system memory is available to be used in OS page cache.
 
 ### Durability
 Database is restored to consistent state if IO is interrupted at any point.
@@ -28,7 +28,7 @@ Each column stores data in a set of 256 value tables, with 255 tables containing
 Metadata file contains database definition. This includes a set of columns with configuration specified for each column.
 
 ### Hash index
-Hash index is an is mmap-backed dynamically sized probing hash table. For each key the index computes a uniformly distributed 256-bit hash 'k'. For index of size `n`, the first `n` bits of `k` map to the 512 byte index page. Each page is an unordered list of 64 8-byte entries. Each 8-byte entry contains a value address and some additional bits of `k`. An empty entry is denoted with a zero value. An empty database starts with `n` = 16. A value address includes a 8-bit value table index and an index of an entry in that table.
+Hash index is an is mmap-backed dynamically sized probing hash table. For each key the index computes a uniformly distributed 256-bit hash 'k'. For index of size `n`, the first `n` bits of `k` map to the 512 byte index page. Each page is an unordered list of 64 8-byte entries. Each 8-byte entry contains a value address and some additional bits of `k`. An empty entry is denoted with a zero value. An empty database starts with `n` = 16. A value address includes an 8-bit value table index and an index of an entry in that table.
 The first 16 kbytes of each index file is used to store statistics for the column.
 
 ### Value tables
@@ -43,7 +43,7 @@ Value table is a linear array of fixed-size entries that can grow as necessary. 
 Compute `k`, find index page using first `n` bits. Search for a matching entry that has matching key bits. Use the address in the entry to query the partial `k` and value from a value table. Confirm that `k` matches expected value.
 
 ### Hash index insertion
-If an insertion is attempted into a full index page a reindex is triggered. 
+If an insertion is attempted into a full index page a reindex is triggered.
 Page size of 64 index entries trigger a reindex once load factor reaches about 0.52.
 
 ### Reindex

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -121,7 +121,7 @@ pub fn run() -> Result<(), String> {
 				}
 			}
 			let db = parity_db::Db::open_or_create(&db_options).unwrap();
-			crate::bench::run_internal(args, db);
+			bench::run_internal(args, db);
 		},
 	}
 	Ok(())

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -30,7 +30,7 @@ impl BTree {
 
 		let root_index =
 			if btree_header.root == NULL_ADDRESS { None } else { Some(btree_header.root) };
-		Ok(btree::BTree::new(root_index, btree_header.depth, record_id))
+		Ok(BTree::new(root_index, btree_header.depth, record_id))
 	}
 
 	pub fn write_sorted_changes(

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -103,7 +103,7 @@ impl<'a> BTreeIterator<'a> {
 			let log = self.log.read();
 			let record_id = log.last_record_id(self.col);
 			// No consistency over iteration, allows dropping lock to overlay.
-			std::mem::drop(commit_overlay);
+			drop(commit_overlay);
 			if record_id != self.iter.1.record_id {
 				self.pending_next_backend = None;
 			}
@@ -179,7 +179,7 @@ impl<'a> BTreeIterator<'a> {
 			let log = self.log.read();
 			let record_id = log.last_record_id(self.col);
 			// No consistency over iteration, allows dropping lock to overlay.
-			std::mem::drop(commit_overlay);
+			drop(commit_overlay);
 			if record_id != self.iter.1.record_id {
 				self.pending_next_backend = None;
 			}

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -147,21 +147,21 @@ impl Node {
 				let insert = i;
 				let insert_separator = Self::create_separator(key, value, btree, log, None)?;
 
-				match insert.cmp(&middle) {
-					std::cmp::Ordering::Equal => {
+				return match insert.cmp(&middle) {
+					Ordering::Equal => {
 						let (right, right_ix) = self.split(middle, true, None, None, has_child);
 						let right = Self::write_split_child(right_ix, right, btree, log)?;
-						return Ok((Some((insert_separator, right)), false))
+						Ok((Some((insert_separator, right)), false))
 					},
-					std::cmp::Ordering::Less => {
+					Ordering::Less => {
 						let (right, right_ix) = self.split(middle, false, None, None, has_child);
 						let sep = self.remove_separator(middle - 1);
 						self.shift_from(insert, has_child, false);
 						self.set_separator(insert, insert_separator);
 						let right = Self::write_split_child(right_ix, right, btree, log)?;
-						return Ok((Some((sep, right)), false))
+						Ok((Some((sep, right)), false))
 					},
-					std::cmp::Ordering::Greater => {
+					Ordering::Greater => {
 						let (right, right_ix) = self.split(
 							middle + 1,
 							false,
@@ -171,7 +171,7 @@ impl Node {
 						);
 						let sep = self.remove_separator(middle);
 						let right = Self::write_split_child(right_ix, right, btree, log)?;
-						return Ok((Some((sep, right)), false))
+						Ok((Some((sep, right)), false))
 					},
 				}
 			}
@@ -203,13 +203,13 @@ impl Node {
 			let insert = at;
 
 			match insert.cmp(&middle) {
-				std::cmp::Ordering::Equal => {
+				Ordering::Equal => {
 					let (mut right, right_ix) = self.split(middle, true, None, None, has_child);
 					right.set_child(0, child);
 					let right = Self::write_split_child(right_ix, right, btree, log)?;
 					Ok(Some((separator, right)))
 				},
-				std::cmp::Ordering::Less => {
+				Ordering::Less => {
 					let (right, right_ix) = self.split(middle, false, None, None, has_child);
 					let sep = self.remove_separator(middle - 1);
 					self.shift_from(insert, has_child, false);
@@ -218,7 +218,7 @@ impl Node {
 					let right = Self::write_split_child(right_ix, right, btree, log)?;
 					Ok(Some((sep, right)))
 				},
-				std::cmp::Ordering::Greater => {
+				Ordering::Greater => {
 					let (right, right_ix) = self.split(
 						middle + 1,
 						false,
@@ -282,10 +282,10 @@ impl Node {
 			if !has_child {
 				return Ok((None, false))
 			}
-			if let Some(mut child) = self.fetch_child(i, values, log)? {
+			return if let Some(mut child) = self.fetch_child(i, values, log)? {
 				let r = child.change(Some((self, i)), depth - 1, changes, values, log)?;
 				self.write_child(i, child, values, log)?;
-				return Ok(match r {
+				Ok(match r {
 					(Some((sep, right)), _) => {
 						// insert from child
 						(self.insert_node(depth, i, sep, right, values, log)?, false)
@@ -297,7 +297,7 @@ impl Node {
 					r => r,
 				})
 			} else {
-				return Ok((None, false))
+				Ok((None, false))
 			}
 		}
 
@@ -628,8 +628,8 @@ impl Node {
 /// (there we need one entry per record id).
 #[derive(Clone, Debug)]
 pub struct Node {
-	pub(super) separators: [node::Separator; ORDER],
-	pub(super) children: [node::Child; ORDER_CHILD],
+	pub(super) separators: [Separator; ORDER],
+	pub(super) children: [Child; ORDER_CHILD],
 	pub(super) changed: bool,
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,7 +5,7 @@
 pub struct HexDisplay<'a>(&'a [u8]);
 
 impl<'a> HexDisplay<'a> {
-	pub fn from<R: std::convert::AsRef<[u8]> + ?Sized>(d: &'a R) -> Self {
+	pub fn from<R: AsRef<[u8]> + ?Sized>(d: &'a R) -> Self {
 		HexDisplay(d.as_ref())
 	}
 }
@@ -13,7 +13,7 @@ impl<'a> HexDisplay<'a> {
 impl<'a> std::fmt::Display for HexDisplay<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		for byte in self.0 {
-			f.write_fmt(format_args!("{:02x}", byte))?;
+			write!(f, "{:02x}", byte)?;
 		}
 		Ok(())
 	}
@@ -22,12 +22,12 @@ impl<'a> std::fmt::Display for HexDisplay<'a> {
 impl<'a> std::fmt::Debug for HexDisplay<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		for byte in self.0 {
-			f.write_fmt(format_args!("{:02x}", byte))?;
+			write!(f, "{:02x}", byte)?;
 		}
 		Ok(())
 	}
 }
 
-pub fn hex<R: std::convert::AsRef<[u8]> + ?Sized>(r: &R) -> HexDisplay<'_> {
+pub fn hex<R: AsRef<[u8]> + ?Sized>(r: &R) -> HexDisplay<'_> {
 	HexDisplay::from(r)
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -332,9 +332,9 @@ impl IndexTable {
 		let new_entry = Entry::new(address, partial_key, self.id.index_bits());
 		if let Some(i) = sub_index {
 			let entry = Self::read_entry(&chunk, i);
-			assert!(
-				entry.partial_key(self.id.index_bits()) ==
-					new_entry.partial_key(self.id.index_bits())
+			assert_eq!(
+				entry.partial_key(self.id.index_bits()),
+				new_entry.partial_key(self.id.index_bits())
 			);
 			Self::write_entry(&new_entry, i, &mut chunk);
 			log::trace!(target: "parity-db", "{}: Replaced at {}.{}: {}", self.id, chunk_index, i, new_entry.address(self.id.index_bits()));
@@ -493,7 +493,7 @@ impl IndexTable {
 	}
 
 	pub fn drop_file(self) -> Result<()> {
-		std::mem::drop(self.map);
+		drop(self.map);
 		std::fs::remove_file(self.path.as_path())?;
 		log::debug!(target: "parity-db", "{}: Dropped table", self.id);
 		Ok(())

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -68,7 +68,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 	for c in 0..source_options.columns.len() as ColId {
 		if !to_migrate.contains(&c) {
 			if !overwrite {
-				std::mem::drop(dest);
+				drop(dest);
 				copy_column(c, from, &to.path)?;
 				dest = Db::open_or_create(&to)?;
 			}
@@ -106,12 +106,12 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 			dest.commit_raw(commit)?;
 			commit = Default::default();
 			nb_commit = 0;
-			std::mem::drop(dest);
+			drop(dest);
 			dest = Db::open_or_create(&to)?; // This is needed to flush logs.
 			log::info!("Collection migrated {}, imported", c);
 
-			std::mem::drop(dest);
-			std::mem::drop(source);
+			drop(dest);
+			drop(source);
 			let mut tmp_dir = from.to_path_buf();
 			tmp_dir.push(OVERWRITE_TMP_PATH);
 			let remove_tmp_dir = || -> Result<()> {
@@ -166,7 +166,7 @@ pub fn clear_column(path: &Path, column: ColId) -> Result<()> {
 	options.columns = meta.columns;
 	options.salt = Some(meta.salt);
 	let _db = Db::open(&options)?;
-	std::mem::drop(_db);
+	drop(_db);
 
 	// It is not specified how read_dir behaves when deleting and iterating in the same loop
 	// We collect a list of paths to be deleted first.

--- a/src/options.rs
+++ b/src/options.rs
@@ -126,7 +126,7 @@ impl Default for ColumnOptions {
 }
 
 impl Options {
-	pub fn with_columns(path: &std::path::Path, num_columns: u8) -> Options {
+	pub fn with_columns(path: &Path, num_columns: u8) -> Options {
 		Options {
 			path: path.into(),
 			sync_wal: true,
@@ -138,14 +138,14 @@ impl Options {
 	}
 
 	// TODO on next major version remove in favor of write_metadata_with_version
-	pub fn write_metadata(&self, path: &std::path::Path, salt: &Salt) -> Result<()> {
+	pub fn write_metadata(&self, path: &Path, salt: &Salt) -> Result<()> {
 		let mut path = path.to_path_buf();
 		path.push("metadata");
 		self.write_metadata_file(&path, salt)
 	}
 
 	// TODO on next major version remove in favor of write_metadata_with_version
-	pub fn write_metadata_file(&self, path: &std::path::Path, salt: &Salt) -> Result<()> {
+	pub fn write_metadata_file(&self, path: &Path, salt: &Salt) -> Result<()> {
 		let mut file = std::fs::File::create(path)?;
 		writeln!(file, "version={}", CURRENT_VERSION)?;
 		writeln!(file, "salt={}", hex::encode(salt))?;
@@ -157,7 +157,7 @@ impl Options {
 
 	pub fn write_metadata_with_version(
 		&self,
-		path: &std::path::Path,
+		path: &Path,
 		salt: &Salt,
 		version: Option<u32>,
 	) -> Result<()> {
@@ -168,7 +168,7 @@ impl Options {
 
 	pub fn write_metadata_file_with_version(
 		&self,
-		path: &std::path::Path,
+		path: &Path,
 		salt: &Salt,
 		version: Option<u32>,
 	) -> Result<()> {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -243,7 +243,7 @@ impl ColumnStats {
 		write_u64(&mut cursor, &self.reference_increase_miss);
 	}
 
-	pub fn write_stats_text(&self, writer: &mut impl std::io::Write, col: ColId) -> Result<()> {
+	pub fn write_stats_text(&self, writer: &mut impl Write, col: ColId) -> Result<()> {
 		writeln!(writer, "Column {}", col)?;
 		writeln!(writer, "Total values: {}", self.total_values.load(Ordering::Relaxed))?;
 		writeln!(writer, "Total bytes: {}", self.total_bytes.load(Ordering::Relaxed))?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -976,7 +976,7 @@ impl ValueTable {
 		let mut log = LogWriter::new(&empty_overlays, 0);
 		let at = self.overwrite_chain(&TableKey::NoHash, entry, &mut log, None, false)?;
 		self.complete_plan(&mut log)?;
-		assert!(at == 1);
+		assert_eq!(at, 1);
 		let log = log.drain();
 		let change = log.local_values_changes(self.id).expect("entry written above");
 		for (at, (_rec_id, entry)) in change.map.iter() {
@@ -1028,7 +1028,7 @@ pub mod key {
 			}
 		}
 
-		pub fn fetch_partial(buf: &mut super::FullEntry) -> Result<[u8; PARTIAL_SIZE]> {
+		pub fn fetch_partial(buf: &mut FullEntry) -> Result<[u8; PARTIAL_SIZE]> {
 			let mut result = [0u8; PARTIAL_SIZE];
 			if buf.1.len() >= PARTIAL_SIZE {
 				let pks = buf.read_partial();
@@ -1038,7 +1038,7 @@ pub mod key {
 			Err(crate::error::Error::InvalidValueData)
 		}
 
-		pub fn fetch(&self, buf: &mut super::FullEntry) -> Result<Option<[u8; PARTIAL_SIZE]>> {
+		pub fn fetch(&self, buf: &mut FullEntry) -> Result<Option<[u8; PARTIAL_SIZE]>> {
 			match self {
 				TableKey::Partial(_k) => Ok(Some(Self::fetch_partial(buf)?)),
 				TableKey::NoHash => Ok(None),


### PR DESCRIPTION
- Avoids qualified paths when not useful
- Use assert_eq! when relevant
- Avoids nested "return" calls
- Minor typo
- Use `write!` instead of `.write_fmt(format_args!(`
- Avoids duplicated .editorconfig constraints