### PR TITLE
Remove incorrect assertion

### DIFF
--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -466,22 +466,3 @@ pub mod commit_overlay {
 		}
 	}
 }
-
-#[test]
-fn test_duplicated_reference_on_ref_counted_btree() {
-	use crate::Db;
-	use tempfile::tempdir;
-	let tmp = tempdir().unwrap();
-	let mut options = Options::with_columns(tmp.path(), 1);
-	options.columns[0].ref_counted = true;
-	options.columns[0].btree_index = true;
-	let db = Db::open_or_create(&options).unwrap();
-	db.commit_changes(vec![
-		(0, Operation::Set(vec![255], vec![8])),
-		(0, Operation::Reference(vec![255])),
-		(0, Operation::Reference(vec![255])),
-		(0, Operation::Set(vec![255], vec![5])),
-	])
-	.unwrap();
-	assert_eq!(db.get(0, &[255]).unwrap(), Some(vec![5]));
-}

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -466,3 +466,22 @@ pub mod commit_overlay {
 		}
 	}
 }
+
+#[test]
+fn test_duplicated_reference_on_ref_counted_btree() {
+	use crate::Db;
+	use tempfile::tempdir;
+	let tmp = tempdir().unwrap();
+	let mut options = Options::with_columns(tmp.path(), 1);
+	options.columns[0].ref_counted = true;
+	options.columns[0].btree_index = true;
+	let db = Db::open_or_create(&options).unwrap();
+	db.commit_changes(vec![
+		(0, Operation::Set(vec![255], vec![8])),
+		(0, Operation::Reference(vec![255])),
+		(0, Operation::Reference(vec![255])),
+		(0, Operation::Set(vec![255], vec![5])),
+	])
+	.unwrap();
+	assert_eq!(db.get(0, &[255]).unwrap(), Some(vec![5]));
+}

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -64,11 +64,19 @@ impl Node {
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
 		loop {
-			if changes.len() > 1 {
-				if changes[0].key() == changes[1].key() &&
-					!changes[0].is_reference_ops() &&
-					!changes[1].is_reference_ops()
-				{
+			if changes.len() > 1 && !changes[0].is_reference_ops() {
+				let mut skip = false;
+				for next in changes[1..].iter() {
+					if changes[0].key() == next.key() {
+						if !next.is_reference_ops() {
+							skip = true;
+							break
+						}
+					} else {
+						break
+					}
+				}
+				if skip {
 					// TODO only when advancing (here rec call useless)
 					*changes = &changes[1..];
 					continue

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -73,7 +73,6 @@ impl Node {
 					*changes = &changes[1..];
 					continue
 				}
-				debug_assert!(changes[0].key() < changes[1].key());
 			}
 			let r = match &changes[0] {
 				Operation::Set(key, value) =>


### PR DESCRIPTION
Removed assertion was incorrect, we skip Set operation on same key so we should not have two consecutive key in this case.
On the other hand whith reference operation on does not overwrite the other, so it make sense to have two consecutive identic keys (can also be key from a set operation).
I also did skip some Set operation when reference is in between to set operation but that's a corner case.

Makes me think reference operation could be optimized to only increase reference once (can be a bit tricky as if at any point the Rc is bellow 0, then folowing calls need to be skipped unless value written again, core pb is that we don't know the rc value when we want to skip such operation and probably don't want to fetch the rc, so should be optimizable but at a different location).

This issue should not happen in hash indexed tables: the change set is not sorted and we don't skip operations.

fix #101 