### PR TITLE
Adds basic model-based fuzzers

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "parity-db-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+arbitrary = { version = "1", features = ["derive"] }
+libfuzzer-sys = "0.4"
+parity-db = { path = ".." }
+tempfile = "3"
+
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "simple_model"
+path = "fuzz_targets/simple_model.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "refcounted_model"
+path = "fuzz_targets/refcounted_model.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,17 @@
+# Parity DB fuzzing
+
+It relies on [cargo fuzz](https://github.com/rust-fuzz/cargo-fuzz).
+There is [a detailed tutorial available](https://rust-fuzz.github.io/book/cargo-fuzz.html).
+
+Two fuzzers are currently available:
+
+- `simple_model`: checks that the database without reference counting behaves like an in-memory collection. It covers both hash-map and b-tree.
+- `recounted_model`: checks that the database without reference counting behaves like an in-memory collection. It covers both hash-map and b-tree.
+
+Both fuzzers currently only checks a sequence of transactions and restarts.
+
+To setup and run the simple model fuzzer run the root directory of Parity DB:
+```shell
+cargo install cargo-fuzz
+cargo +nightly fuzz run simple_model
+```

--- a/fuzz/fuzz_targets/refcounted_model.rs
+++ b/fuzz/fuzz_targets/refcounted_model.rs
@@ -1,0 +1,131 @@
+// Copyright 2021-2022 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or MIT.
+
+//! Model check with reference counting:
+//! Checks that a sequence of operations and restarts behaves the same as an in-memory collection.
+
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::collections::btree_map::{BTreeMap, Entry};
+use tempfile::tempdir;
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum Operation {
+	Set(u8, u8),
+	Dereference(u8),
+	Reference(u8),
+}
+
+#[derive(Arbitrary, Debug)]
+enum Action {
+	Transaction(Vec<Operation>),
+	Restart,
+}
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum CompressionType {
+	NoCompression,
+	Snappy,
+	Lz4,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Config {
+	btree_index: bool,
+	compression: CompressionType,
+}
+
+fuzz_target!(|entry: (Config, Vec<Action>)| {
+	let (config, actions) = entry;
+	let dir = tempdir().unwrap();
+	let options = parity_db::Options {
+		path: dir.path().to_owned(),
+		columns: vec![parity_db::ColumnOptions {
+			ref_counted: true,
+			compression: match config.compression {
+				CompressionType::NoCompression => parity_db::CompressionType::NoCompression,
+				CompressionType::Snappy => parity_db::CompressionType::Snappy,
+				CompressionType::Lz4 => parity_db::CompressionType::Lz4,
+			},
+			btree_index: config.btree_index,
+			..parity_db::ColumnOptions::default()
+		}],
+		sync_wal: true,
+		sync_data: true,
+		stats: false,
+		salt: None,
+	};
+	let mut db = parity_db::Db::open_or_create(&options).unwrap();
+	let mut model = BTreeMap::<u8, (usize, u8)>::default();
+	for action in actions {
+		// We apply the action on both the database and the model
+		match action {
+			Action::Transaction(operations) => {
+				db.commit_changes(operations.iter().copied().map(|op| {
+					(
+						0u8,
+						match op {
+							Operation::Set(k, v) => parity_db::Operation::Set(vec![k], vec![v]),
+							Operation::Dereference(k) => parity_db::Operation::Dereference(vec![k]),
+							Operation::Reference(k) => parity_db::Operation::Reference(vec![k]),
+						},
+					)
+				}))
+				.unwrap();
+				for op in operations {
+					match op {
+						Operation::Set(k, v) => {
+							model.insert(k, (1, v));
+						},
+						Operation::Dereference(k) => {
+							if let Entry::Occupied(mut e) = model.entry(k) {
+								let (mut counter, _) = e.get_mut();
+								counter -= 1;
+								if counter == 0 {
+									e.remove_entry();
+								}
+							}
+						},
+						Operation::Reference(k) =>
+							if let Some((counter, _)) = model.get_mut(&k) {
+								*counter += 1;
+							},
+					}
+				}
+			},
+			Action::Restart =>
+				db = {
+					drop(db);
+					parity_db::Db::open_or_create(&options).unwrap()
+				},
+		}
+
+		// We check the state
+		for (k, (_, v)) in &model {
+			assert_eq!(db.get(0, &[*k]).unwrap(), Some(vec![*v]));
+		}
+
+		if config.btree_index {
+			// We check the BTree forward iterator
+			let mut model_content = model.iter().map(|(k, (_, v))| (*k, *v)).collect::<Vec<_>>();
+			let mut db_iter = db.iter(0).unwrap();
+			db_iter.seek_to_first().unwrap();
+			let mut db_content = Vec::new();
+			while let Some((k, v)) = db_iter.next().unwrap() {
+				db_content.push((k[0], v[0]));
+			}
+			assert_eq!(db_content, model_content);
+
+			// We check the BTree backward iterator
+			model_content.reverse();
+			let mut db_iter = db.iter(0).unwrap();
+			db_iter.seek_to_last().unwrap();
+			let mut db_content = Vec::new();
+			while let Some((k, v)) = db_iter.prev().unwrap() {
+				db_content.push((k[0], v[0]));
+			}
+			assert_eq!(db_content, model_content);
+		}
+	}
+});

--- a/fuzz/fuzz_targets/simple_model.rs
+++ b/fuzz/fuzz_targets/simple_model.rs
@@ -1,0 +1,102 @@
+// Copyright 2021-2022 Parity Technologies (UK) Ltd.
+// This file is dual-licensed as Apache-2.0 or MIT.
+
+//! Model check without reference counting:
+//! Checks that a sequence of operations and restarts behaves the same as an in-memory collection.
+
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::collections::btree_map::BTreeMap;
+use tempfile::tempdir;
+
+#[derive(Arbitrary, Debug)]
+enum Action {
+	Transaction(Vec<(u8, Option<u8>)>),
+	Restart,
+}
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum CompressionType {
+	NoCompression,
+	Snappy,
+	Lz4,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Config {
+	btree_index: bool,
+	compression: CompressionType,
+}
+
+fuzz_target!(|entry: (Config, Vec<Action>)| {
+	let (config, actions) = entry;
+	let dir = tempdir().unwrap();
+	let options = parity_db::Options {
+		path: dir.path().to_owned(),
+		columns: vec![parity_db::ColumnOptions {
+			compression: match config.compression {
+				CompressionType::NoCompression => parity_db::CompressionType::NoCompression,
+				CompressionType::Snappy => parity_db::CompressionType::Snappy,
+				CompressionType::Lz4 => parity_db::CompressionType::Lz4,
+			},
+			btree_index: config.btree_index,
+			..parity_db::ColumnOptions::default()
+		}],
+		sync_wal: true,
+		sync_data: true,
+		stats: false,
+		salt: None,
+	};
+	let mut db = parity_db::Db::open_or_create(&options).unwrap();
+	let mut model = BTreeMap::<u8, u8>::default();
+	for action in actions {
+		// We apply the action on both the database and the model
+		match action {
+			Action::Transaction(operations) => {
+				db.commit(
+					operations.iter().copied().map(|(k, v)| (0u8, vec![k], v.map(|v| vec![v]))),
+				)
+				.unwrap();
+				for (k, v) in operations {
+					if let Some(v) = v {
+						model.insert(k, v);
+					} else {
+						model.remove(&k);
+					}
+				}
+			},
+			Action::Restart =>
+				db = {
+					drop(db);
+					parity_db::Db::open_or_create(&options).unwrap()
+				},
+		}
+
+		// We check the state
+		for (k, v) in &model {
+			assert_eq!(db.get(0, &[*k]).unwrap(), Some(vec![*v]));
+		}
+
+		if config.btree_index {
+			// We check the BTree forward iterator
+			let mut model_content = model.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>();
+			let mut db_iter = db.iter(0).unwrap();
+			db_iter.seek_to_first().unwrap();
+			let mut db_content = Vec::new();
+			while let Some((k, v)) = db_iter.next().unwrap() {
+				db_content.push((k[0], v[0]));
+			}
+			assert_eq!(db_content, model_content);
+
+			// We check the BTree backward iterator
+			model_content.reverse();
+			db_iter.seek_to_last().unwrap();
+			let mut db_content = Vec::new();
+			while let Some((k, v)) = db_iter.prev().unwrap() {
+				db_content.push((k[0], v[0]));
+			}
+			assert_eq!(db_content, model_content);
+		}
+	}
+});


### PR DESCRIPTION
Checks that the database behaves like an in-memory collection when a sequence of transactions and restarts are applied.

Covered cases:
- hash map and btree (for btree iteration order is checked)
- the 3 compressions
- reference counting or not