### PR TITLE
Makes Db::commit_raw private

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -918,7 +918,7 @@ impl Db {
 		self.inner.commit_changes(tx)
 	}
 
-	pub fn commit_raw(&self, commit: CommitChangeSet) -> Result<()> {
+	pub(crate) fn commit_raw(&self, commit: CommitChangeSet) -> Result<()> {
 		self.inner.commit_raw(commit)
 	}
 


### PR DESCRIPTION
CommitChangeSet is already private so this method is already unusable outside parity-db