### PR TITLE
allow using ref count for btree column

### DIFF
--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -268,7 +268,7 @@ impl BTreeTable {
 			&Operation::Dereference(()),
 			writer,
 			None,
-			true,
+			false,
 		)?;
 		Ok(())
 	}
@@ -331,7 +331,7 @@ impl BTreeTable {
 				&Operation::Set((), entry.encoded),
 				writer,
 				None,
-				true,
+				false,
 			)? {
 				Some(new_index)
 			} else {
@@ -455,7 +455,7 @@ pub mod commit_overlay {
 					&Operation::Set((), &entry.encoded.as_ref()[..HEADER_SIZE as usize]),
 					writer,
 					None,
-					true,
+					false,
 				)?;
 			}
 			#[cfg(test)]

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -64,23 +64,13 @@ impl Node {
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
 		loop {
-			if changes.len() > 1 && !changes[0].is_reference_ops() {
-				let mut skip = false;
-				for next in changes[1..].iter() {
-					if changes[0].key() == next.key() {
-						if !next.is_reference_ops() {
-							skip = true;
-							break
-						}
-					} else {
-						break
-					}
-				}
-				if skip {
-					// TODO only when advancing (here rec call useless)
-					*changes = &changes[1..];
-					continue
-				}
+			if !btree.ref_counted &&
+				changes.len() > 1 &&
+				!matches!(changes[1], Operation::Reference(..)) &&
+				changes[0].key() == changes[1].key()
+			{
+				*changes = &changes[1..];
+				continue
 			}
 			let r = match &changes[0] {
 				Operation::Set(key, value) =>
@@ -260,30 +250,35 @@ impl Node {
 		if at {
 			let existing = self.separator_address(i);
 			if let Some(existing) = existing {
-				Column::write_existing_value_plan::<_, Vec<u8>>(
+				if Column::write_existing_value_plan::<_, Vec<u8>>(
 					&TableKey::NoHash,
 					values,
 					existing,
 					change,
 					log,
 					None,
-				)?;
-			}
-			let _ = self.remove_separator(i);
-			if depth != 0 {
-				// replace by bigger value in left child.
-				if let Some(mut child) = self.fetch_child(i, values, log)? {
-					let (need_balance, sep) = child.remove_last(depth - 1, values, log)?;
-					self.write_child(i, child, values, log)?;
-					if let Some(sep) = sep {
-						self.set_separator(i, sep);
-					}
-					if need_balance {
-						self.rebalance(depth, i, values, log)?;
+					false,
+				)?
+				.0
+				.is_none()
+				{
+					let _ = self.remove_separator(i);
+					if depth != 0 {
+						// replace by bigger value in left child.
+						if let Some(mut child) = self.fetch_child(i, values, log)? {
+							let (need_balance, sep) = child.remove_last(depth - 1, values, log)?;
+							self.write_child(i, child, values, log)?;
+							if let Some(sep) = sep {
+								self.set_separator(i, sep);
+							}
+							if need_balance {
+								self.rebalance(depth, i, values, log)?;
+							}
+						}
+					} else {
+						self.remove_from(i, false, true);
 					}
 				}
-			} else {
-				self.remove_from(i, false, true);
 			}
 		} else {
 			if !has_child {
@@ -665,12 +660,6 @@ pub struct Child {
 }
 
 impl Node {
-	pub fn clear(&mut self) {
-		self.separators = Default::default();
-		self.children = Default::default();
-		self.changed = true;
-	}
-
 	pub fn from_encoded(enc: Vec<u8>) -> Self {
 		let mut entry = Entry::from_encoded(enc);
 		let mut node =
@@ -757,13 +746,15 @@ impl Node {
 				&Operation::Set((), value),
 				log,
 				None,
+				false,
 			)?
 			.1
 			.unwrap_or(address)
 		} else {
 			Column::write_new_value_plan(&TableKey::NoHash, btree, value, log, None)?
 		};
-		Ok(Separator { modified: true, separator: Some(SeparatorInner { key, value }) })
+		let modified = Some(value) != existing;
+		Ok(Separator { modified, separator: Some(SeparatorInner { key, value }) })
 	}
 
 	fn split(

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -257,7 +257,7 @@ impl Node {
 					change,
 					log,
 					None,
-					false,
+					values.ref_counted,
 				)?
 				.0
 				.is_none()
@@ -746,7 +746,7 @@ impl Node {
 				&Operation::Set((), value),
 				log,
 				None,
-				false,
+				btree.ref_counted,
 			)?
 			.1
 			.unwrap_or(address)

--- a/src/column.rs
+++ b/src/column.rs
@@ -520,7 +520,7 @@ impl HashColumn {
 			change,
 			log,
 			stats,
-			false,
+			self.ref_counted,
 		)? {
 			(Some(outcome), _) => Ok(outcome),
 			(None, Some(value_address)) => {
@@ -887,7 +887,7 @@ impl Column {
 		change: &Operation<K, V>,
 		log: &mut LogWriter,
 		stats: Option<&ColumnStats>,
-		btree_index_node: bool,
+		ref_counted: bool,
 	) -> Result<(Option<PlanOutcome>, Option<Address>)> {
 		let tier = address.size_tier() as usize;
 
@@ -910,7 +910,7 @@ impl Column {
 
 		match change {
 			Operation::Reference(_) =>
-				if tables.ref_counted && !btree_index_node {
+				if ref_counted {
 					log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 					tables.tables[tier].write_inc_ref(address.offset(), log)?;
 					if let Some(stats) = stats {
@@ -921,7 +921,7 @@ impl Column {
 					Ok((Some(PlanOutcome::Skipped), None))
 				},
 			Operation::Set(_, val) => {
-				if tables.ref_counted && !btree_index_node {
+				if ref_counted {
 					log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 					tables.tables[tier].write_inc_ref(address.offset(), log)?;
 					return Ok((Some(PlanOutcome::Written), None))
@@ -969,7 +969,7 @@ impl Column {
 			Operation::Dereference(_) => {
 				// Deletion
 				let cur_size = if stats.is_some() { Some(fetch_size()?) } else { None };
-				let remove = if tables.ref_counted && !btree_index_node {
+				let remove = if ref_counted {
 					let removed = !tables.tables[tier].write_dec_ref(address.offset(), log)?;
 					log::trace!(target: "parity-db", "{}: Dereference {}, deleted={}", tables.col, key, removed);
 					removed

--- a/src/column.rs
+++ b/src/column.rs
@@ -520,6 +520,7 @@ impl HashColumn {
 			change,
 			log,
 			stats,
+			false,
 		)? {
 			(Some(outcome), _) => Ok(outcome),
 			(None, Some(value_address)) => {
@@ -886,6 +887,7 @@ impl Column {
 		change: &Operation<K, V>,
 		log: &mut LogWriter,
 		stats: Option<&ColumnStats>,
+		btree_index_node: bool,
 	) -> Result<(Option<PlanOutcome>, Option<Address>)> {
 		let tier = address.size_tier() as usize;
 
@@ -908,7 +910,7 @@ impl Column {
 
 		match change {
 			Operation::Reference(_) =>
-				if tables.ref_counted {
+				if tables.ref_counted && !btree_index_node {
 					log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 					tables.tables[tier].write_inc_ref(address.offset(), log)?;
 					if let Some(stats) = stats {
@@ -919,7 +921,7 @@ impl Column {
 					Ok((Some(PlanOutcome::Skipped), None))
 				},
 			Operation::Set(_, val) => {
-				if tables.ref_counted {
+				if tables.ref_counted && !btree_index_node {
 					log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 					tables.tables[tier].write_inc_ref(address.offset(), log)?;
 					return Ok((Some(PlanOutcome::Written), None))
@@ -967,7 +969,7 @@ impl Column {
 			Operation::Dereference(_) => {
 				// Deletion
 				let cur_size = if stats.is_some() { Some(fetch_size()?) } else { None };
-				let remove = if tables.ref_counted {
+				let remove = if tables.ref_counted && !btree_index_node {
 					let removed = !tables.tables[tier].write_dec_ref(address.offset(), log)?;
 					log::trace!(target: "parity-db", "{}: Dereference {}, deleted={}", tables.col, key, removed);
 					removed

--- a/src/db.rs
+++ b/src/db.rs
@@ -1884,7 +1884,7 @@ mod tests {
 					state.remove(k);
 				}
 			}
-			for (key, value) in state.into_iter() {
+			for (key, value) in state {
 				assert_eq!(db.get(col_nb, &key).unwrap(), value.map(|v| v.0));
 			}
 		} else {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1169,13 +1169,6 @@ impl<Key, Value> Operation<Key, Value> {
 			Operation::Set(k, _) | Operation::Dereference(k) | Operation::Reference(k) => k,
 		}
 	}
-
-	pub fn is_reference_ops(&self) -> bool {
-		match self {
-			Operation::Set(..) | Operation::Dereference(..) => false,
-			Operation::Reference(..) => true,
-		}
-	}
 }
 
 impl<K: AsRef<[u8]>, Value> Operation<K, Value> {
@@ -1824,25 +1817,36 @@ mod tests {
 	}
 
 	fn test_basic(change_set: &[(Vec<u8>, Option<Vec<u8>>)]) {
+		test_basic_inner(change_set, false, false);
+		test_basic_inner(change_set, false, true);
+		test_basic_inner(change_set, true, false);
+		test_basic_inner(change_set, true, true);
+	}
+
+	fn test_basic_inner(
+		change_set: &[(Vec<u8>, Option<Vec<u8>>)],
+		btree_index: bool,
+		ref_counted: bool,
+	) {
 		let tmp = tempdir().unwrap();
 		let col_nb = 1u8;
 		let mut options = Options::with_columns(tmp.path(), 2);
-		options.columns[col_nb as usize].btree_index = true;
+		options.columns[col_nb as usize].btree_index = btree_index;
+		options.columns[col_nb as usize].ref_counted = ref_counted;
 		let db_test = EnableCommitPipelineStages::DbFile;
+		// ref counted and commit overlay currently don't support removal
+		assert!(!(ref_counted && matches!(db_test, EnableCommitPipelineStages::CommitOverlay)));
 		let inner_options =
 			InternalOptions { create: true, commit_stages: db_test, ..Default::default() };
 		let db = Db::open_inner(&options, &inner_options).unwrap();
 
-		let mut iter = db.iter(col_nb).unwrap();
-		assert_eq!(iter.next().unwrap(), None);
+		let iter = btree_index.then(|| db.iter(col_nb).unwrap());
+		assert_eq!(iter.and_then(|mut i| i.next().unwrap()), None);
 
-		db.commit(change_set.iter().map(|(k, v)| (0, k.clone(), v.clone()))).unwrap();
 		db.commit(change_set.iter().map(|(k, v)| (col_nb, k.clone(), v.clone())))
 			.unwrap();
 		db_test.run_stages(&db);
 
-		let stats = db.stats();
-		let col_stats = stats.columns.into_iter().next().unwrap().unwrap();
 		let mut keys = HashSet::new();
 		let mut expected_count: u64 = 0;
 		for (k, v) in change_set.iter() {
@@ -1854,12 +1858,47 @@ mod tests {
 				expected_count -= 1;
 			}
 		}
-		assert_eq!(col_stats.total_values, expected_count);
+		if ref_counted {
+			let mut state: BTreeMap<Vec<u8>, Option<(Vec<u8>, usize)>> = Default::default();
+			for (k, v) in change_set.iter() {
+				let mut remove = false;
+				let mut insert = false;
+				match state.get_mut(k) {
+					Some(Some((_, counter))) =>
+						if v.is_some() {
+							*counter += 1;
+						} else if *counter == 1 {
+							remove = true;
+						} else {
+							*counter -= 1;
+						},
+					Some(None) | None =>
+						if v.is_some() {
+							insert = true;
+						},
+				}
+				if insert {
+					state.insert(k.clone(), v.clone().map(|v| (v, 1)));
+				}
+				if remove {
+					state.remove(k);
+				}
+			}
+			for (key, value) in state.into_iter() {
+				assert_eq!(db.get(col_nb, &key).unwrap(), value.map(|v| v.0));
+			}
+		} else {
+			let stats = db.stats();
+			// btree do not have stats implemented
+			if let Some(stats) = stats.columns[col_nb as usize].as_ref() {
+				assert_eq!(stats.total_values, expected_count);
+			}
 
-		let state: BTreeMap<Vec<u8>, Option<Vec<u8>>> =
-			change_set.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-		for (key, value) in state.iter() {
-			assert_eq!(&db.get(col_nb, key).unwrap(), value);
+			let state: BTreeMap<Vec<u8>, Option<Vec<u8>>> =
+				change_set.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+			for (key, value) in state.iter() {
+				assert_eq!(&db.get(col_nb, key).unwrap(), value);
+			}
 		}
 	}
 
@@ -1904,6 +1943,22 @@ mod tests {
 
 	#[test]
 	fn test_simple() {
+		test_basic(&[
+			(b"key1".to_vec(), Some(b"value1".to_vec())),
+			(b"key1".to_vec(), Some(b"value1".to_vec())),
+			(b"key1".to_vec(), None),
+		]);
+		test_basic(&[
+			(b"key1".to_vec(), Some(b"value1".to_vec())),
+			(b"key1".to_vec(), Some(b"value1".to_vec())),
+			(b"key1".to_vec(), None),
+			(b"key1".to_vec(), None),
+		]);
+		test_basic(&[
+			(b"key1".to_vec(), Some(b"value1".to_vec())),
+			(b"key1".to_vec(), Some(b"value2".to_vec())),
+		]);
+		test_basic(&[(b"key1".to_vec(), Some(b"value1".to_vec()))]);
 		test_basic(&[
 			(b"key1".to_vec(), Some(b"value1".to_vec())),
 			(b"key2".to_vec(), Some(b"value2".to_vec())),


### PR DESCRIPTION
Fix #104 

BTree columns were never used before with ref counted. My first idea was to forbid it, but it was fairly implementable I think.

A new parameter was added to write_existing_value to be able to use rc logic only on value (and not on indexing nodes).
While debugging I also found that root was uslessly written twice, so I did remove a write_plan function (second time was noop since changes where already writte).
Also had to disable node removal when the rc change did not delete value.
Also removed the node parent of the value marked as modified if the value index did not change. 