### PR TITLE
Replace blake2-rfc with blake2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/parity-db/"
 description = "Key-value database for the blockchain"
 
 [dependencies]
-blake2-rfc = "0.2.18"
+blake2 = "0.10.4"
 crc32fast = "1.2.0"
 fs2 = "0.4.3"
 hex = "0.4.2"

--- a/src/column.rs
+++ b/src/column.rs
@@ -125,6 +125,11 @@ enum IterStateOrCorrupted {
 
 #[inline]
 pub fn hash_key(key: &[u8], salt: &Salt, uniform: bool, db_version: u32) -> Key {
+	use blake2::{
+		digest::{typenum::U32, FixedOutput, Update},
+		Blake2bMac,
+	};
+
 	let mut k = Key::default();
 	if uniform {
 		if db_version <= 5 {
@@ -137,7 +142,11 @@ pub fn hash_key(key: &[u8], salt: &Salt, uniform: bool, db_version: u32) -> Key 
 			}
 		}
 	} else {
-		k.copy_from_slice(blake2_rfc::blake2b::blake2b(32, salt, key).as_bytes());
+		let mut ctx = Blake2bMac::<U32>::new_with_salt_and_personal(salt, &[], &[])
+			.expect("Salt length (32) is a valid key length (<= 64)");
+		ctx.update(key);
+		let hash = ctx.finalize_fixed();
+		k.copy_from_slice(&hash);
 	}
 	k
 }
@@ -676,6 +685,8 @@ impl HashColumn {
 		start_chunk: u64,
 		skip_preimage_indexes: bool,
 	) -> Result<()> {
+		use blake2::{digest::typenum::U32, Blake2b, Digest};
+
 		let tables = self.tables.read();
 		let source = &tables.index;
 
@@ -694,8 +705,8 @@ impl HashColumn {
 					} else {
 						value
 					};
-					let key = blake2_rfc::blake2b::blake2b(32, &[], &value);
-					let key = self.hash_key(key.as_bytes());
+					let key = Blake2b::<U32>::digest(&value);
+					let key = self.hash_key(&key);
 					let state = IterStateOrCorrupted::Item(IterState {
 						chunk_index: index,
 						key,

--- a/src/table.rs
+++ b/src/table.rs
@@ -1147,8 +1147,10 @@ mod test {
 	}
 
 	fn key(k: u32) -> Key {
+		use blake2::{digest::typenum::U32, Blake2b, Digest};
 		let mut key = Key::default();
-		key.copy_from_slice(blake2_rfc::blake2b::blake2b(32, &[], &k.to_le_bytes()).as_bytes());
+		let hash = Blake2b::<U32>::digest(&k.to_le_bytes());
+		key.copy_from_slice(&hash);
 		key
 	}
 


### PR DESCRIPTION
Currently Parity-DB is the only crate used by Substrate that is using `blake2-rfc`.

Everything else has been recently ported to RustCrypto `blake2`.

---

Please refer to this Substrate PR for some more details: https://github.com/paritytech/substrate/pull/12266