### PR TITLE
Allows to simulate I/O errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/parity-db/"
 description = "Key-value database for the blockchain"
 
+[features]
+instrumentation = []
+
 [dependencies]
 blake2 = "0.10.4"
 crc32fast = "1.2.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
-parity-db = { path = ".." }
+parity-db = { path = "..", features = ["instrumentation"] }
 tempfile = "3"
 
 [workspace]

--- a/src/column.rs
+++ b/src/column.rs
@@ -664,7 +664,7 @@ impl HashColumn {
 	pub fn write_stats_text(&self, writer: &mut impl std::io::Write) -> Result<()> {
 		let tables = self.tables.read();
 		tables.index.write_stats(&self.stats);
-		self.stats.write_stats_text(writer, tables.index.id.col())
+		self.stats.write_stats_text(writer, tables.index.id.col()).map_err(Error::Io)
 	}
 
 	fn stat_summary(&self) -> ColumnStatSummary {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod table;
 pub use btree::BTreeIterator;
 pub use compress::CompressionType;
 pub use db::{check::CheckOptions, Db, Operation, Value};
+#[cfg(feature = "instrumentation")]
+pub use error::set_number_of_allowed_io_operations;
 pub use error::{Error, Result};
 pub use migration::{clear_column, migrate};
 pub use options::{ColumnOptions, Options};

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,7 +4,7 @@
 use crate::{
 	column::{ColId, Salt},
 	compress::CompressionType,
-	error::{Error, Result},
+	error::{try_io, Error, Result},
 };
 use rand::Rng;
 use std::{collections::HashMap, path::Path};
@@ -174,7 +174,7 @@ impl Options {
 		for i in 0..self.columns.len() {
 			metadata.push(format!("col{}={}", i, self.columns[i].as_string()));
 		}
-		std::fs::write(path, metadata.join("\n"))?;
+		try_io!(std::fs::write(path, metadata.join("\n")));
 		Ok(())
 	}
 
@@ -220,12 +220,12 @@ impl Options {
 		if !path.exists() {
 			return Ok(None)
 		}
-		let file = std::io::BufReader::new(std::fs::File::open(path)?);
+		let file = std::io::BufReader::new(try_io!(std::fs::File::open(path)));
 		let mut salt = None;
 		let mut columns = Vec::new();
 		let mut version = 0;
 		for l in file.lines() {
-			let l = l?;
+			let l = try_io!(l);
 			let mut vals = l.split('=');
 			let k = vals.next().ok_or_else(|| Error::Corruption("Bad metadata".into()))?;
 			let v = vals.next().ok_or_else(|| Error::Corruption("Bad metadata".into()))?;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Parity Technologies (UK) Ltd.
 // This file is dual-licensed as Apache-2.0 or MIT.
 
-use crate::{column::ColId, error::Result, table::SIZE_TIERS};
+use crate::{column::ColId, table::SIZE_TIERS};
 /// Database statistics.
 use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
 use std::{
@@ -243,7 +243,7 @@ impl ColumnStats {
 		write_u64(&mut cursor, &self.reference_increase_miss);
 	}
 
-	pub fn write_stats_text(&self, writer: &mut impl Write, col: ColId) -> Result<()> {
+	pub fn write_stats_text(&self, writer: &mut impl Write, col: ColId) -> std::io::Result<()> {
 		writeln!(writer, "Column {}", col)?;
 		writeln!(writer, "Total values: {}", self.total_values.load(Ordering::Relaxed))?;
 		writeln!(writer, "Total bytes: {}", self.total_bytes.load(Ordering::Relaxed))?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -47,7 +47,7 @@
 use crate::{
 	column::ColId,
 	display::hex,
-	error::Result,
+	error::{try_io, Result},
 	log::{LogQuery, LogReader, LogWriter},
 	options::ColumnOptions as Options,
 	table::key::{TableKey, TableKeyQuery, PARTIAL_SIZE},
@@ -356,7 +356,7 @@ impl ValueTable {
 		let mut last_removed = 0;
 		if let Some(file) = &mut *file.file.write() {
 			let mut header = Header::default();
-			file.read_exact(&mut header.0)?;
+			try_io!(file.read_exact(&mut header.0));
 			last_removed = header.last_removed();
 			filled = header.filled();
 			if filled == 0 {


### PR DESCRIPTION
Introduces the "instrumentation" feature.

When enabled the "set_number_of_allowed_io_operations" is exposed and allows to set the number of allowed I/O operations.
After this threshold is reached all I/O operations returns an error.

This required to wrap all I/O calls with the new "try_io!" macro that is an alias for "try!" if the "instrumentation" feature is not enabled.