### PR TITLE
Fuzzer: Properly support instrumented errors during "drop"

### DIFF
--- a/fuzz/fuzz_targets/refcounted_model.rs
+++ b/fuzz/fuzz_targets/refcounted_model.rs
@@ -79,5 +79,5 @@ impl DbSimulator for Simulator {
 
 fuzz_target!(|entry: (Config, Vec<Action<Operation>>)| {
 	let (config, actions) = entry;
-	Simulator::simulate(config, actions).unwrap();
+	Simulator::simulate(config, actions);
 });

--- a/fuzz/fuzz_targets/simple_model.rs
+++ b/fuzz/fuzz_targets/simple_model.rs
@@ -59,5 +59,5 @@ impl DbSimulator for Simulator {
 
 fuzz_target!(|entry: (Config, Vec<Action<(u8, Option<u8>)>>)| {
 	let (config, actions) = entry;
-	Simulator::simulate(config, actions).unwrap();
+	Simulator::simulate(config, actions);
 });


### PR DESCRIPTION
Also do not instrument DB construction, in order to avoid quick failure due to #114