### PR TITLE
Fuzzer: Ref-counted: makes sure to don't wrongly resurrect values

### DIFF
--- a/fuzz/fuzz_targets/refcounted_model.rs
+++ b/fuzz/fuzz_targets/refcounted_model.rs
@@ -56,7 +56,9 @@ impl DbSimulator for Simulator {
 				},
 			Operation::Reference(k) =>
 				if let Entry::Occupied(mut e) = model.entry(k) {
-					*e.get_mut() += 1;
+					if *e.get() > 0 {
+						*e.get_mut() += 1;
+					}
 				},
 		}
 	}


### PR DESCRIPTION
If a value as usage count 0 then it might be GC so if a new reference is added to it should not make it alive again