### PR TITLE
Minor code cleanups

### DIFF
--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -132,14 +132,14 @@ impl<'a> BTreeIterator<'a> {
 			let log = self.log.read();
 			let record_id = log.last_record_id(self.col);
 			// No consistency over iteration, allows dropping lock to overlay.
-			std::mem::drop(commit_overlay);
+			drop(commit_overlay);
 			if record_id != self.iter.1.record_id {
 				self.pending_backend = None;
 			}
 			let next_from_pending = self
 				.pending_backend
 				.take()
-				.and_then(|pending| (pending.direction == direction).then(|| pending.next_item));
+				.and_then(|pending| (pending.direction == direction).then_some(pending.next_item));
 			let next_backend = if let Some(pending) = next_from_pending {
 				pending
 			} else {

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -795,7 +795,7 @@ impl Node {
 	}
 
 	// Return true if match and matched position.
-	// Return index of first element bigger than key otherwhise.
+	// Return index of first element bigger than key otherwise.
 	fn position(&self, key: &[u8]) -> Result<(bool, usize)> {
 		let mut i = 0;
 		while let Some(separator) = self.separators[i].separator.as_ref() {

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -713,7 +713,7 @@ impl Node {
 		}
 		let mut offset = 0;
 		if has_child {
-			let skip_offset = if skip_left_child { 1 } else { 0 };
+			let skip_offset = usize::from(skip_left_child);
 			for i in right_start + skip_offset..ORDER_CHILD {
 				let child = self.remove_child(i);
 				if insert_right_child.as_ref().map(|ins| ins.0 + 1 == i).unwrap_or(false) {

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -6,7 +6,7 @@
 use crate::error::Result;
 
 /// Different compression type
-/// allowend and their u8 representation.
+/// allowed and their u8 representation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum CompressionType {

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,12 +1,13 @@
 // Copyright 2021-2022 Parity Technologies (UK) Ltd.
 // This file is dual-licensed as Apache-2.0 or MIT.
 
+//! Utilities for db file.
+
 use crate::{
 	error::{try_io, Result},
 	table::TableId,
 };
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
-/// Utilites for db file.
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 #[cfg(target_os = "linux")]

--- a/src/log.rs
+++ b/src/log.rs
@@ -811,7 +811,7 @@ impl Log {
 		match reader.next() {
 			Ok(LogAction::BeginRecord) => Ok(Some(reader)),
 			Ok(_) => Err(Error::Corruption("Bad log record structure".into())),
-			Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+			Err(Error::Io(e)) if e.kind() == ErrorKind::UnexpectedEof => {
 				*reading_state = ReadingState::Idle;
 				self.done_reading_cv.notify_one();
 				log::debug!(target: "parity-db", "Read: End of log");

--- a/src/table.rs
+++ b/src/table.rs
@@ -1158,7 +1158,7 @@ mod test {
 	fn key(k: u32) -> Key {
 		use blake2::{digest::typenum::U32, Blake2b, Digest};
 		let mut key = Key::default();
-		let hash = Blake2b::<U32>::digest(&k.to_le_bytes());
+		let hash = Blake2b::<U32>::digest(k.to_le_bytes());
 		key.copy_from_slice(&hash);
 		key
 	}


### PR DESCRIPTION
- Clippy suggestions
- Comments position in the file (avoids `use` calls both before and after the main comment of the file)
- Typos