### PR TITLE
Changing version to v0.4.0 for release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+The format is based on [Keep a Changelog].
+
+[Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
+
+## [Unreleased]
+
+## [0.4.0] - 2022-09-28
+- Compression threshold moved to modifiable starting option. [#103](https://github.com/paritytech/parity-db/pull/103)
+- Iterator behave like rust std btree when changing direction [#125](https://github.com/paritytech/parity-db/pull/125)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.3.17"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I added a CHANGE_LOG too, I just did put the two item that breaks api that I remember of.

Plan to release 0.4.0 as CI test failure from substate looks correlated to behavior on change of record_id.
(does not fix the corruption observed by user though)