### PR TITLE
Recovery: only clear log on corruption

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -535,12 +535,13 @@ impl DbInner {
 					loop {
 						let next = match reader.next() {
 							Ok(next) => next,
-							Err(e) => {
-								log::debug!(target: "parity-db", "Error reading log: {:?}", e);
+							Err(Error::Corruption(e)) => {
+								log::debug!(target: "parity-db", "Bad log content: {}", e);
 								drop(reader);
 								self.log.clear_replay_logs()?;
 								return Ok(false)
 							},
+							Err(e) => return Err(e),
 						};
 						match next {
 							LogAction::BeginRecord => {


### PR DESCRIPTION
Avoids to drop all logs in case of e.g. an I/O error or a bug in the code.

It's already the behavior when opening the reader.