### PR TITLE
Clean all logs after recovery

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -723,6 +723,9 @@ impl DbInner {
 			c.refresh_metadata()?;
 		}
 		log::debug!(target: "parity-db", "Replay is complete.");
+		log::debug!(target: "parity-db", "Cleaning logs.");
+		self.clean_all_logs()?;
+		log::debug!(target: "parity-db", "Log cleanup completed.");
 		Ok(())
 	}
 


### PR DESCRIPTION
Allows to make sure no old log is staying after proper recovery

Fixes #145