### PR TITLE
Avoid a race-condition leading to crash in Log::clean_logs

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use parking_lot::{RwLock, RwLockWriteGuard};
 use std::{
+	cmp::min,
 	collections::{HashMap, VecDeque},
 	convert::TryInto,
 	io::{ErrorKind, Read, Seek, Write},
@@ -698,8 +699,12 @@ impl Log {
 		}
 	}
 
-	pub fn clean_logs(&self, count: usize) -> Result<bool> {
-		let mut cleaned: Vec<_> = { self.cleanup_queue.write().drain(0..count).collect() };
+	pub fn clean_logs(&self, max_count: usize) -> Result<bool> {
+		let mut cleaned: Vec<_> = {
+			let mut queue = self.cleanup_queue.write();
+			let count = min(max_count, queue.len());
+			queue.drain(0..count).collect()
+		};
 		for (id, ref mut file) in cleaned.iter_mut() {
 			log::debug!(target: "parity-db", "Cleaned: {}", id);
 			try_io!(file.seek(std::io::SeekFrom::Start(0)));


### PR DESCRIPTION
If Log.cleanup_queue is partially drained between the computation of the number of logs to clean (the "count" parameter) and the actual call to "drain", the drain method was panicking.

The changed code only drains at most the number of elements of the queue, avoiding the panic risk.

Found using Loom