### PR TITLE
Fix index corruption on reindex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/column.rs
+++ b/src/column.rs
@@ -418,7 +418,7 @@ impl HashColumn {
 		log: &mut LogWriter,
 	) -> Result<PlanOutcome> {
 		if Self::contains_partial_key_with_address(key, address, &tables.index, log)? {
-			log::info!(target: "parity-db", "{}: Skipped reindex entry {} when reindexing", tables.index.id, hex(key));
+			log::trace!(target: "parity-db", "{}: Skipped reindex entry {} when reindexing", tables.index.id, hex(key));
 			return Ok(PlanOutcome::Skipped)
 		}
 		let mut outcome = PlanOutcome::Written;
@@ -593,7 +593,7 @@ impl HashColumn {
 		while let PlanOutcome::NeedReindex =
 			tables.index.write_insert_plan(key, address, None, log)?
 		{
-			log::info!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));
+			log::debug!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));
 			(tables, reindex) = Self::trigger_reindex(tables, reindex, self.path.as_path());
 			outcome = PlanOutcome::NeedReindex;
 		}

--- a/src/column.rs
+++ b/src/column.rs
@@ -879,8 +879,7 @@ impl HashColumn {
 				}
 				log::debug!(target: "parity-db", "{}: Continue reindex at {}/{}", tables.index.id, source_index, source.id.total_chunks());
 				while source_index < source.id.total_chunks() && plan.len() < MAX_REINDEX_BATCH {
-					//log::trace!(target: "parity-db", "{}: Reindexing {}", source.id,
-					// source_index);
+					log::trace!(target: "parity-db", "{}: Reindexing {}", source.id, source_index);
 					let entries = source.entries(source_index, log.overlays())?;
 					for entry in entries.iter() {
 						if entry.is_empty() {

--- a/src/column.rs
+++ b/src/column.rs
@@ -359,8 +359,10 @@ impl HashColumn {
 			if let Some(table) = IndexTable::open_existing(path, id)? {
 				if top.is_none() {
 					stats = table.load_stats()?;
+					log::trace!(target: "parity-db", "Opened main index {}", table.id);
 					top = Some(table);
 				} else {
+					log::trace!(target: "parity-db", "Opened stale index {}", table.id);
 					reindexing.push_front(table);
 				}
 			}
@@ -409,24 +411,25 @@ impl HashColumn {
 
 	fn write_reindex_plan_locked<'a, 'b>(
 		&self,
-		tables: RwLockUpgradableReadGuard<'a, Tables>,
-		reindex: RwLockUpgradableReadGuard<'b, Reindex>,
+		mut tables: RwLockUpgradableReadGuard<'a, Tables>,
+		mut reindex: RwLockUpgradableReadGuard<'b, Reindex>,
 		key: &Key,
 		address: Address,
 		log: &mut LogWriter,
 	) -> Result<PlanOutcome> {
-		if Self::search_index(key, &tables.index, &tables, log)?.is_some() {
+		if Self::contains_partial_key_with_address(key, address, &tables.index, log)? {
+			log::info!(target: "parity-db", "{}: Skipped reindex entry {} when reindexing", tables.index.id, hex(key));
 			return Ok(PlanOutcome::Skipped)
 		}
-		match tables.index.write_insert_plan(key, address, None, log)? {
-			PlanOutcome::NeedReindex => {
-				log::debug!(target: "parity-db", "{}: Index chunk full {} when reindexing", tables.index.id, hex(key));
-				let (tables, reindex) = Self::trigger_reindex(tables, reindex, self.path.as_path());
-				self.write_reindex_plan_locked(tables, reindex, key, address, log)?;
-				Ok(PlanOutcome::NeedReindex)
-			},
-			_ => Ok(PlanOutcome::Written),
+		let mut outcome = PlanOutcome::Written;
+		while let PlanOutcome::NeedReindex =
+			tables.index.write_insert_plan(key, address, None, log)?
+		{
+			log::info!(target: "parity-db", "{}: Index chunk full {} when reindexing", tables.index.id, hex(key));
+			(tables, reindex) = Self::trigger_reindex(tables, reindex, self.path.as_path());
+			outcome = PlanOutcome::NeedReindex;
 		}
+		Ok(outcome)
 	}
 
 	fn search_index<'a>(
@@ -453,6 +456,25 @@ impl HashColumn {
 			sub_index = next_index;
 		}
 		Ok(None)
+	}
+
+	fn contains_partial_key_with_address<'a>(
+		key: &Key,
+		address: Address,
+		index: &'a IndexTable,
+		log: &LogWriter,
+	) -> Result<bool> {
+		let (mut existing_entry, mut sub_index) = index.get(key, 0, log)?;
+		while !existing_entry.is_empty() {
+			let existing_address = existing_entry.address(index.id.index_bits());
+			if existing_address == address {
+				return Ok(true)
+			}
+			let (next_entry, next_index) = index.get(key, sub_index + 1, log)?;
+			existing_entry = next_entry;
+			sub_index = next_index;
+		}
+		Ok(false)
 	}
 
 	fn search_all_indexes<'a>(
@@ -548,8 +570,8 @@ impl HashColumn {
 
 	fn write_plan_new<'a, 'b>(
 		&self,
-		tables: RwLockUpgradableReadGuard<'a, Tables>,
-		reindex: RwLockUpgradableReadGuard<'b, Reindex>,
+		mut tables: RwLockUpgradableReadGuard<'a, Tables>,
+		mut reindex: RwLockUpgradableReadGuard<'b, Reindex>,
 		key: &Key,
 		value: &[u8],
 		log: &mut LogWriter,
@@ -567,15 +589,15 @@ impl HashColumn {
 			log,
 			stats,
 		)?;
-		match tables.index.write_insert_plan(key, address, None, log)? {
-			PlanOutcome::NeedReindex => {
-				log::debug!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));
-				let (tables, reindex) = Self::trigger_reindex(tables, reindex, self.path.as_path());
-				let (_, t, r) = self.write_plan_new(tables, reindex, key, value, log)?;
-				Ok((PlanOutcome::NeedReindex, t, r))
-			},
-			_ => Ok((PlanOutcome::Written, tables, reindex)),
+		let mut outcome = PlanOutcome::Written;
+		while let PlanOutcome::NeedReindex =
+			tables.index.write_insert_plan(key, address, None, log)?
+		{
+			log::info!(target: "parity-db", "{}: Index chunk full {}", tables.index.id, hex(key));
+			(tables, reindex) = Self::trigger_reindex(tables, reindex, self.path.as_path());
+			outcome = PlanOutcome::NeedReindex;
 		}
+		Ok((outcome, tables, reindex))
 	}
 
 	pub fn enact_plan(&self, action: LogAction, log: &mut LogReader) -> Result<()> {
@@ -620,6 +642,11 @@ impl HashColumn {
 				} else if let Some(table) = reindex.queue.iter().find(|r| r.id == record.table) {
 					table.validate_plan(record.index, log)?;
 				} else {
+					if record.table.index_bits() < tables.index.id.index_bits() {
+						// Insertion into a previously dropped index.
+						log::warn!( target: "parity-db", "Index {} is too old. Current is {}", record.table, tables.index.id);
+						return Err(Error::Corruption("Unexpected log index id".to_string()))
+					}
 					// Re-launch previously started reindex
 					// TODO: add explicit log records for reindexing events.
 					log::warn!(
@@ -627,7 +654,8 @@ impl HashColumn {
 						"Missing table {}, starting reindex",
 						record.table,
 					);
-					let _lock = Self::trigger_reindex(tables, reindex, self.path.as_path());
+					let lock = Self::trigger_reindex(tables, reindex, self.path.as_path());
+					std::mem::drop(lock);
 					return self.validate_plan(LogAction::InsertIndex(record), log)
 				}
 			},
@@ -723,7 +751,7 @@ impl HashColumn {
 					});
 					f(state).unwrap_or(false)
 				})?;
-				log::debug!( target: "parity-db", "{}: Done Iterating table {}", source.id, table.id);
+				log::debug!( target: "parity-db", "{}: Done iterating table {}", source.id, table.id);
 			}
 		}
 
@@ -851,7 +879,8 @@ impl HashColumn {
 				}
 				log::debug!(target: "parity-db", "{}: Continue reindex at {}/{}", tables.index.id, source_index, source.id.total_chunks());
 				while source_index < source.id.total_chunks() && plan.len() < MAX_REINDEX_BATCH {
-					log::trace!(target: "parity-db", "{}: Reindexing {}", source.id, source_index);
+					//log::trace!(target: "parity-db", "{}: Reindexing {}", source.id,
+					// source_index);
 					let entries = source.entries(source_index, log.overlays())?;
 					for entry in entries.iter() {
 						if entry.is_empty() {
@@ -1084,6 +1113,14 @@ impl Column {
 		match self {
 			Column::Hash(column) => column.dump(log, check_param, col),
 			Column::Tree(_column) => Ok(()),
+		}
+	}
+
+	#[cfg(test)]
+	pub fn index_bits(&self) -> Option<u8> {
+		match self {
+			Column::Hash(column) => Some(column.tables.read().index.id.index_bits()),
+			Column::Tree(_column) => None,
 		}
 	}
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -527,7 +527,7 @@ impl DbInner {
 			if let Some(mut reader) = reader {
 				log::debug!(
 					target: "parity-db",
-					"Enacting log {}",
+					"Enacting log record {}",
 					reader.record_id(),
 				);
 				if validation_mode {

--- a/src/index.rs
+++ b/src/index.rs
@@ -231,11 +231,12 @@ impl IndexTable {
 		Ok(try_io!(Ok(&map[offset..offset + CHUNK_LEN])))
 	}
 
+	#[inline(never)]
 	fn find_entry(&self, key_prefix: u64, sub_index: usize, chunk: &[u8]) -> (Entry, usize) {
 		let partial_key = Entry::extract_key(key_prefix, self.id.index_bits());
 		for i in sub_index..CHUNK_ENTRIES {
 			let entry = Self::read_entry(chunk, i);
-			if !entry.is_empty() && entry.partial_key(self.id.index_bits()) == partial_key {
+			if entry.partial_key(self.id.index_bits()) == partial_key {
 				return (entry, i)
 			}
 		}

--- a/src/index.rs
+++ b/src/index.rs
@@ -353,7 +353,7 @@ impl IndexTable {
 				return Ok(PlanOutcome::Written)
 			}
 		}
-		log::trace!(target: "parity-db", "{}: Full at {}", self.id, chunk_index);
+		log::trace!(target: "parity-db", "{}: Index chunk full at {}", self.id, chunk_index);
 		Ok(PlanOutcome::NeedReindex)
 	}
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -181,7 +181,7 @@ impl TableId {
 
 impl std::fmt::Display for TableId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{:02}-{:02}", self.col(), self.index_bits())
+		write!(f, "i{:02}-{:02}", self.col(), self.index_bits())
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod stats;
 mod table;
 
 pub use btree::BTreeIterator;
+pub use column::ColId;
 pub use compress::CompressionType;
 pub use db::{check::CheckOptions, Db, Operation, Value};
 #[cfg(feature = "instrumentation")]

--- a/src/table.rs
+++ b/src/table.rs
@@ -118,7 +118,7 @@ impl TableId {
 
 impl std::fmt::Display for TableId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{:02}-{:02}", self.col(), hex(&[self.size_tier()]))
+		write!(f, "t{:02}-{:02}", self.col(), hex(&[self.size_tier()]))
 	}
 }
 
@@ -455,7 +455,7 @@ impl ValueTable {
 								self.id,
 								index,
 								k,
-								to_fetch,
+								to_fetch.as_ref().map(hex),
 								self.entry_size,
 							);
 							return Ok((0, false))
@@ -849,6 +849,7 @@ impl ValueTable {
 			let mut header = Header::default();
 			log.read(&mut header.0)?;
 			self.file.write_at(&header.0, 0)?;
+			log::trace!(target: "parity-db", "{}: Enacted header, {} filled", self.id, header.filled());
 			return Ok(())
 		}
 


### PR DESCRIPTION
An interrupted reindexing process would result in duplicated index entries on the next attempt. The check for existing entries when reindexing is incorrect, as it checks for full key when only partial key is available.