### PR TITLE
IndexTable::find_entry: add assertion bound checking

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -233,6 +233,7 @@ impl IndexTable {
 
 	#[inline(never)]
 	fn find_entry(&self, key_prefix: u64, sub_index: usize, chunk: &[u8]) -> (Entry, usize) {
+		assert!(chunk.len() >= CHUNK_ENTRIES * 8);
 		let partial_key = Entry::extract_key(key_prefix, self.id.index_bits());
 		for i in sub_index..CHUNK_ENTRIES {
 			let entry = Self::read_entry(chunk, i);


### PR DESCRIPTION
Allows to avoid a bound check on each `read_entry` call