### PR TITLE
Reduce alloc in copy_to_overlay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ snap = "1"
 loom = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 fdlimit = "0.2.1"
 rand = { version = "0.8.2", features = ["small_rng"] }
 tempfile = "3.2"

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -234,9 +234,8 @@ pub trait DbSimulator {
 							retry_operation(|| iter.seek_to_last());
 							IterPosition::End
 						};
-						let new_key_value = iter
-							.prev()
-							.unwrap_or_else(|e| {
+						let new_key_value =
+							iter.prev().unwrap_or_else(|e| {
 								log::debug!("Database error: {}, restarting iter.prev without I/O limitations.", e);
 
 								// We ignore the error and reset the iterator
@@ -244,8 +243,7 @@ pub trait DbSimulator {
 								iter.seek_to_last().unwrap();
 								old_key = IterPosition::End;
 								iter.prev().unwrap()
-							})
-							.map(|(k, v)| (k.value().clone(), v.value().clone()));
+							});
 						let expected = Self::valid_iter_value(old_key, &layers, Ordering::Greater);
 						log::info!(
 							"Prev lookup on iterator with old position {:?}, expecting one of {:?}",
@@ -267,9 +265,8 @@ pub trait DbSimulator {
 							retry_operation(|| iter.seek_to_first());
 							IterPosition::Start
 						};
-						let new_key_value = iter
-							.next()
-							.unwrap_or_else(|e| {
+						let new_key_value =
+							iter.next().unwrap_or_else(|e| {
 								log::debug!("Database error: {}, restarting iter.next without I/O limitations.", e);
 
 								// We ignore the error and reset the iterator
@@ -277,8 +274,7 @@ pub trait DbSimulator {
 								iter.seek_to_first().unwrap();
 								old_key = IterPosition::Start;
 								iter.next().unwrap()
-							})
-							.map(|(k, v)| (k.value().clone(), v.value().clone()));
+							});
 						let expected = Self::valid_iter_value(old_key, &layers, Ordering::Less);
 						log::info!(
 							"Next lookup on iterator with old position {:?}, expecting one of {:?}",

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::{
 	btree::BTreeTable,
 	column::Column,
+	db::ValuePtr,
 	error::Result,
 	log::{LogQuery, LogWriter},
 	table::key::TableKeyQuery,
@@ -35,7 +36,7 @@ impl BTree {
 
 	pub fn write_sorted_changes(
 		&mut self,
-		mut changes: &[Operation<Vec<u8>, Vec<u8>>],
+		mut changes: &[Operation<ValuePtr, ValuePtr>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<()> {
@@ -55,7 +56,7 @@ impl BTree {
 					root.set_child(1, right);
 					root.set_separator(0, sep);
 				},
-				(_, true) =>
+				(_, true) => {
 					if let Some((node_index, node)) = root.need_remove_root(btree, log)? {
 						self.depth -= 1;
 						if let Some(index) = self.root_index.take() {
@@ -63,7 +64,8 @@ impl BTree {
 						}
 						self.root_index = node_index;
 						root = node;
-					},
+					}
+				},
 				_ => (),
 			}
 			*changes = &changes[1..];

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::{
 	btree::BTreeTable,
 	column::Column,
-	db::ValuePtr,
+	db::{RcKey, RcValue},
 	error::Result,
 	log::{LogQuery, LogWriter},
 	table::key::TableKeyQuery,
@@ -36,7 +36,7 @@ impl BTree {
 
 	pub fn write_sorted_changes(
 		&mut self,
-		mut changes: &[Operation<ValuePtr, ValuePtr>],
+		mut changes: &[Operation<RcKey, RcValue>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<()> {

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -56,7 +56,7 @@ impl BTree {
 					root.set_child(1, right);
 					root.set_separator(0, sep);
 				},
-				(_, true) => {
+				(_, true) =>
 					if let Some((node_index, node)) = root.need_remove_root(btree, log)? {
 						self.depth -= 1;
 						if let Some(index) = self.root_index.take() {
@@ -64,8 +64,7 @@ impl BTree {
 						}
 						self.root_index = node_index;
 						root = node;
-					}
-				},
+					},
 				_ => (),
 			}
 			*changes = &changes[1..];

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -10,7 +10,7 @@
 use super::*;
 use crate::{
 	btree::BTreeTable,
-	db::{CommitOverlay, ValuePtr},
+	db::{CommitOverlay, RcKey, RcValue},
 	error::Result,
 	log::LogQuery,
 	parking_lot::RwLock,
@@ -45,7 +45,7 @@ pub struct BTreeIterator<'a> {
 	last_key: LastKey,
 }
 
-type IterResult = Result<Option<(ValuePtr, ValuePtr)>>;
+type IterResult = Result<Option<(RcKey, RcValue)>>;
 
 #[derive(Debug)]
 struct PendingBackend {
@@ -57,8 +57,8 @@ struct PendingBackend {
 pub enum LastKey {
 	Start,
 	End,
-	At(ValuePtr),
-	Seeked(ValuePtr),
+	At(RcValue),
+	Seeked(RcValue),
 }
 
 #[derive(Debug)]

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -61,7 +61,7 @@ impl Entry {
 
 	fn read_separator(&mut self) -> Option<SeparatorInner> {
 		if self.encoded.offset() == self.encoded.inner_mut().len() {
-			return None;
+			return None
 		}
 		let value = self.encoded.read_u64();
 		let head = self.encoded.read_slice(1);
@@ -69,7 +69,7 @@ impl Entry {
 		let size = if head == u8::MAX { self.encoded.read_u32() as usize } else { head as usize };
 		let key = self.encoded.read_slice(size).to_vec();
 		if value == 0 {
-			return None;
+			return None
 		}
 		let value = Address::from_u64(value);
 		Some(SeparatorInner { key, value })
@@ -188,7 +188,7 @@ impl BTreeTable {
 	pub fn get(key: &[u8], log: &impl LogQuery, values: TablesRef) -> Result<Option<Vec<u8>>> {
 		let btree_header = Self::btree_header(log, values)?;
 		if btree_header.root == NULL_ADDRESS {
-			return Ok(None);
+			return Ok(None)
 		}
 		let record_id = 0; // lifetime of Btree is the query, so no invalidate.
 				   // keeping log locked when parsing tree.
@@ -240,7 +240,7 @@ impl BTreeTable {
 			},
 			_ => {
 				log::error!(target: "parity-db", "Unexpected log action");
-				return Err(Error::Corruption("Unexpected log action".to_string()));
+				return Err(Error::Corruption("Unexpected log action".to_string()))
 			},
 		}
 		Ok(())
@@ -289,7 +289,7 @@ impl BTreeTable {
 			if child.moved {
 				node.changed = true;
 			} else if child.entry_index.is_none() {
-				break;
+				break
 			}
 		}
 
@@ -297,12 +297,12 @@ impl BTreeTable {
 			if separator.modified {
 				node.changed = true;
 			} else if separator.separator.is_none() {
-				break;
+				break
 			}
 		}
 
 		if !node.changed {
-			return Ok(None);
+			return Ok(None)
 		}
 
 		let mut entry = Entry::empty();
@@ -316,13 +316,13 @@ impl BTreeTable {
 			}
 			i_children += 1;
 			if i_children == ORDER_CHILD {
-				break;
+				break
 			}
 			if let Some(sep) = &node.separators.as_mut()[i_separator].separator {
 				entry.write_separator(&sep.key, sep.value);
 				i_separator += 1
 			} else {
-				break;
+				break
 			}
 		}
 
@@ -412,7 +412,7 @@ pub mod commit_overlay {
 							return Err(Error::InvalidInput(format!(
 								"No Rc for column {}",
 								self.col
-							)));
+							)))
 						}
 					},
 				}

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -357,14 +357,14 @@ pub mod commit_overlay {
 	use super::*;
 	use crate::{
 		column::{ColId, Column},
-		db::{BTreeCommitOverlay, Operation, ValuePtr},
+		db::{BTreeCommitOverlay, Operation, RcKey, RcValue},
 		error::Result,
 	};
 
 	#[derive(Debug)]
 	pub struct BTreeChangeSet {
 		pub col: ColId,
-		pub changes: Vec<Operation<ValuePtr, ValuePtr>>,
+		pub changes: Vec<Operation<RcKey, RcValue>>,
 	}
 
 	impl BTreeChangeSet {

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
 	column::Column,
-	db::ValuePtr,
+	db::{RcKey, RcValue},
 	error::Result,
 	index::Address,
 	log::{LogQuery, LogWriter},
@@ -56,7 +56,7 @@ impl Node {
 		&mut self,
 		parent: Option<(&mut Self, usize)>,
 		depth: u32,
-		changes: &mut &[Operation<ValuePtr, ValuePtr>],
+		changes: &mut &[Operation<RcKey, RcValue>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
@@ -106,7 +106,7 @@ impl Node {
 		depth: u32,
 		key: &[u8],
 		value: &[u8],
-		changes: &mut &[Operation<ValuePtr, ValuePtr>],
+		changes: &mut &[Operation<RcKey, RcValue>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
@@ -236,7 +236,7 @@ impl Node {
 	fn on_existing(
 		&mut self,
 		depth: u32,
-		changes: &mut &[Operation<ValuePtr, ValuePtr>],
+		changes: &mut &[Operation<RcKey, RcValue>],
 		values: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
@@ -247,7 +247,7 @@ impl Node {
 		if at {
 			let existing = self.separator_address(i);
 			if let Some(existing) = existing {
-				if Column::write_existing_value_plan::<_, ValuePtr>(
+				if Column::write_existing_value_plan::<_, RcValue>(
 					&TableKey::NoHash,
 					values,
 					existing,

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::{
 	column::Column,
+	db::ValuePtr,
 	error::Result,
 	index::Address,
 	log::{LogQuery, LogWriter},
@@ -55,47 +56,48 @@ impl Node {
 		&mut self,
 		parent: Option<(&mut Self, usize)>,
 		depth: u32,
-		changes: &mut &[Operation<Vec<u8>, Vec<u8>>],
+		changes: &mut &[Operation<ValuePtr, ValuePtr>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
 		loop {
-			if !btree.ref_counted &&
-				changes.len() > 1 &&
-				!matches!(changes[1], Operation::Reference(..)) &&
-				changes[0].key() == changes[1].key()
+			if !btree.ref_counted
+				&& changes.len() > 1
+				&& !matches!(changes[1], Operation::Reference(..))
+				&& changes[0].key() == changes[1].key()
 			{
 				*changes = &changes[1..];
-				continue
+				continue;
 			}
 			let r = match &changes[0] {
-				Operation::Set(key, value) =>
-					self.insert(depth, key, value, changes, btree, log)?,
+				Operation::Set(key, value) => {
+					self.insert(depth, key.value(), value.value(), changes, btree, log)?
+				},
 				_ => self.on_existing(depth, changes, btree, log)?,
 			};
 			if r.0.is_some() || r.1 {
-				return Ok(r)
+				return Ok(r);
 			}
 			if changes.len() == 1 {
-				break
+				break;
 			}
 			if let Some((parent, p)) = &parent {
 				let key = &changes[1].key();
-				let (at, i) = self.position(key)?; // TODO could start position from current
+				let (at, i) = self.position(key.value())?; // TODO could start position from current
 				if at || i < self.number_separator() {
 					*changes = &changes[1..];
-					continue
+					continue;
 				}
-				let (at, i) = parent.position(key)?;
+				let (at, i) = parent.position(key.value())?;
 				if !at && &i == p && i < parent.number_separator() {
 					*changes = &changes[1..];
-					continue
+					continue;
 				}
 				// Could check other parents for case i == parent.number_separator.
 				// Would mean unsafe Vec<*mut>, or other complex design: skipping
 				// this case.
 			}
-			break
+			break;
 		}
 		Ok((None, false))
 	}
@@ -105,7 +107,7 @@ impl Node {
 		depth: u32,
 		key: &[u8],
 		value: &[u8],
-		changes: &mut &[Operation<Vec<u8>, Vec<u8>>],
+		changes: &mut &[Operation<ValuePtr, ValuePtr>],
 		btree: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
@@ -131,7 +133,7 @@ impl Node {
 					}
 				} else {
 					(None, false)
-				})
+				});
 			}
 
 			if self.has_separator(ORDER - 1) {
@@ -166,7 +168,7 @@ impl Node {
 						let right = Self::write_split_child(right_ix, right, btree, log)?;
 						Ok((Some((sep, right)), false))
 					},
-				}
+				};
 			}
 
 			self.shift_from(i, has_child, false);
@@ -235,18 +237,18 @@ impl Node {
 	fn on_existing(
 		&mut self,
 		depth: u32,
-		changes: &mut &[Operation<Vec<u8>, Vec<u8>>],
+		changes: &mut &[Operation<ValuePtr, ValuePtr>],
 		values: TablesRef,
 		log: &mut LogWriter,
 	) -> Result<(Option<(Separator, Child)>, bool)> {
 		let change = &changes[0];
 		let key = change.key();
 		let has_child = depth != 0;
-		let (at, i) = self.position(key)?;
+		let (at, i) = self.position(key.value())?;
 		if at {
 			let existing = self.separator_address(i);
 			if let Some(existing) = existing {
-				if Column::write_existing_value_plan::<_, Vec<u8>>(
+				if Column::write_existing_value_plan::<_, ValuePtr>(
 					&TableKey::NoHash,
 					values,
 					existing,
@@ -278,7 +280,7 @@ impl Node {
 			}
 		} else {
 			if !has_child {
-				return Ok((None, false))
+				return Ok((None, false));
 			}
 			return if let Some(mut child) = self.fetch_child(i, values, log)? {
 				let r = child.change(Some((self, i)), depth - 1, changes, values, log)?;
@@ -296,7 +298,7 @@ impl Node {
 				})
 			} else {
 				Ok((None, false))
-			}
+			};
 		}
 
 		Ok((None, self.need_rebalance()))
@@ -339,7 +341,7 @@ impl Node {
 			right.set_separator(0, separator);
 			self.write_child(at - 1, left, values, log)?;
 			self.write_child(at, right, values, log)?;
-			return Ok(())
+			return Ok(());
 		}
 
 		let number_child = self.number_separator() + 1;
@@ -372,7 +374,7 @@ impl Node {
 			}
 			self.write_child(at, left, values, log)?;
 			self.write_child(at + 1, right, values, log)?;
-			return Ok(())
+			return Ok(());
 		}
 
 		let (at, at_right) = if at + 1 == number_child {
@@ -435,7 +437,7 @@ impl Node {
 		if self.number_separator() == 0 && self.fetch_child(0, values, log)?.is_some() {
 			if let Some(node) = self.fetch_child(0, values, log)? {
 				let child = self.remove_child(0);
-				return Ok(Some((child.entry_index, node)))
+				return Ok(Some((child.entry_index, node)));
 			}
 		}
 		Ok(None)
@@ -450,7 +452,7 @@ impl Node {
 		let last = if let Some(last) = self.last_separator_index() {
 			last
 		} else {
-			return Ok((false, None))
+			return Ok((false, None));
 		};
 		let i = last;
 		if depth == 0 {
@@ -482,7 +484,7 @@ impl Node {
 			Ok(self.separator_address(i))
 		} else {
 			if let Some(child) = self.fetch_child(i, values, log)? {
-				return child.get(key, values, log)
+				return child.get(key, values, log);
 			}
 
 			Ok(None)
@@ -510,18 +512,18 @@ impl Node {
 					SeekTo::Include(_) => (LastIndex::Seeked(i), from),
 					SeekTo::Last => unreachable!(),
 				});
-				return Ok(())
+				return Ok(());
 			}
 			if depth == 0 {
 				stack.push((LastIndex::Before(i), from));
-				return Ok(())
+				return Ok(());
 			}
 			if let Some(child) = from.fetch_child(i, values, log)? {
 				stack.push((LastIndex::Descend(i), from));
 				from = child;
 				depth -= 1
 			} else {
-				return Err(Error::Corruption(format!("A btree node is missing a child at {i:?}")))
+				return Err(Error::Corruption(format!("A btree node is missing a child at {i:?}")));
 			}
 		}
 	}
@@ -535,7 +537,7 @@ impl Node {
 	) -> Result<bool> {
 		let size = self.number_separator();
 		if parent_size != 0 && size < ORDER / 2 {
-			return Ok(false)
+			return Ok(false);
 		}
 
 		let mut i = 0;
@@ -543,10 +545,10 @@ impl Node {
 			let child = self.fetch_child(i, tables, log)?;
 			i += 1;
 			if child.is_none() {
-				continue
+				continue;
 			}
 			if !child.unwrap().is_balanced(tables, log, size)? {
-				return Ok(false)
+				return Ok(false);
 			}
 		}
 
@@ -601,13 +603,13 @@ impl Node {
 			}
 			i_children += 1;
 			if i_children == ORDER_CHILD {
-				break
+				break;
 			}
 			if let Some(sep) = entry.read_separator() {
 				node.separators.as_mut()[i_separator].separator = Some(sep);
 				i_separator += 1
 			} else {
-				break
+				break;
 			}
 		}
 		node
@@ -742,7 +744,7 @@ impl Node {
 			current.modified = true;
 			i += 1;
 			if i == ORDER {
-				break
+				break;
 			}
 			current = std::mem::replace(&mut self.separators[i], current);
 		}
@@ -753,7 +755,7 @@ impl Node {
 				current.moved = true;
 				i += 1;
 				if i == ORDER_CHILD {
-					break
+					break;
 				}
 				current = std::mem::replace(&mut self.children[i], current);
 			}
@@ -767,7 +769,7 @@ impl Node {
 			self.separators.as_mut()[i] = self.remove_separator(i + 1);
 			self.separators.as_mut()[i].modified = true;
 			if self.separators.as_mut()[i].separator.is_none() {
-				break
+				break;
 			}
 			i += 1;
 		}
@@ -776,7 +778,7 @@ impl Node {
 			while i < ORDER_CHILD - 1 {
 				self.children.as_mut()[i] = self.remove_child(i + 1);
 				if self.children.as_mut()[i].entry_index.is_none() {
-					break
+					break;
 				}
 				i += 1;
 			}
@@ -788,7 +790,7 @@ impl Node {
 		while self.separators[i].separator.is_some() {
 			i += 1;
 			if i == ORDER {
-				break
+				break;
 			}
 		}
 		i
@@ -806,7 +808,7 @@ impl Node {
 			}
 			i += 1;
 			if i == ORDER {
-				break
+				break;
 			}
 		}
 		Ok((false, i))
@@ -820,7 +822,7 @@ impl Node {
 	) -> Result<Option<Self>> {
 		if let Some(ix) = self.children[i].entry_index {
 			let entry = BTreeTable::get_encoded_entry(ix, log, values)?;
-			return Ok(Some(Self::from_encoded(entry)))
+			return Ok(Some(Self::from_encoded(entry)));
 		}
 		Ok(None)
 	}

--- a/src/column.rs
+++ b/src/column.rs
@@ -167,14 +167,14 @@ impl HashColumn {
 			if self.collect_stats {
 				self.stats.query_hit(tier);
 			}
-			return Ok(Some(value));
+			return Ok(Some(value))
 		}
 		for r in &self.reindex.read().queue {
 			if let Some((tier, value)) = self.get_in_index(key, r, values, log)? {
 				if self.collect_stats {
 					self.stats.query_hit(tier);
 				}
-				return Ok(Some(value));
+				return Ok(Some(value))
 			}
 		}
 		if self.collect_stats {
@@ -238,7 +238,7 @@ impl Column {
 			tables.tables[size_tier].query(&mut key, address.offset(), log)?
 		{
 			let value = if compressed { tables.compression.decompress(&value)? } else { value };
-			return Ok(Some((size_tier as u8, value)));
+			return Ok(Some((size_tier as u8, value)))
 		}
 		Ok(None)
 	}
@@ -419,7 +419,7 @@ impl HashColumn {
 	) -> Result<PlanOutcome> {
 		if Self::contains_partial_key_with_address(key, address, &tables.index, log)? {
 			log::trace!(target: "parity-db", "{}: Skipped reindex entry {} when reindexing", tables.index.id, hex(key));
-			return Ok(PlanOutcome::Skipped);
+			return Ok(PlanOutcome::Skipped)
 		}
 		let mut outcome = PlanOutcome::Written;
 		while let PlanOutcome::NeedReindex =
@@ -448,7 +448,7 @@ impl HashColumn {
 				&table_key,
 				log,
 			)? {
-				return Ok(Some((index, sub_index, existing_address)));
+				return Ok(Some((index, sub_index, existing_address)))
 			}
 
 			let (next_entry, next_index) = index.get(key, sub_index + 1, log)?;
@@ -468,7 +468,7 @@ impl HashColumn {
 		while !existing_entry.is_empty() {
 			let existing_address = existing_entry.address(index.id.index_bits());
 			if existing_address == address {
-				return Ok(true);
+				return Ok(true)
 			}
 			let (next_entry, next_index) = index.get(key, sub_index + 1, log)?;
 			existing_entry = next_entry;
@@ -484,13 +484,13 @@ impl HashColumn {
 		log: &LogWriter,
 	) -> Result<Option<(&'a IndexTable, usize, Address)>> {
 		if let Some(r) = Self::search_index(key, &tables.index, tables, log)? {
-			return Ok(Some(r));
+			return Ok(Some(r))
 		}
 		// Check old indexes
 		// TODO: don't search if index precedes reindex progress
 		for index in &reindex.queue {
 			if let Some(r) = Self::search_index(key, index, tables, log)? {
-				return Ok(Some(r));
+				return Ok(Some(r))
 			}
 		}
 		Ok(None)
@@ -646,7 +646,7 @@ impl HashColumn {
 					if record.table.index_bits() < tables.index.id.index_bits() {
 						// Insertion into a previously dropped index.
 						log::warn!( target: "parity-db", "Index {} is too old. Current is {}", record.table, tables.index.id);
-						return Err(Error::Corruption("Unexpected log index id".to_string()));
+						return Err(Error::Corruption("Unexpected log index id".to_string()))
 					}
 					// Re-launch previously started reindex
 					// TODO: add explicit log records for reindexing events.
@@ -657,7 +657,7 @@ impl HashColumn {
 					);
 					let lock = Self::trigger_reindex(tables, reindex, self.path.as_path());
 					std::mem::drop(lock);
-					return self.validate_plan(LogAction::InsertIndex(record), log);
+					return self.validate_plan(LogAction::InsertIndex(record), log)
 				}
 			},
 			LogAction::InsertValue(record) => {
@@ -665,7 +665,7 @@ impl HashColumn {
 			},
 			_ => {
 				log::error!(target: "parity-db", "Unexpected log action");
-				return Err(Error::Corruption("Unexpected log action".to_string()));
+				return Err(Error::Corruption("Unexpected log action".to_string()))
 			},
 		}
 		Ok(())
@@ -709,9 +709,8 @@ impl HashColumn {
 	pub fn iter_while(&self, log: &Log, mut f: impl FnMut(IterState) -> bool) -> Result<()> {
 		let action = |state| match state {
 			IterStateOrCorrupted::Item(item) => Ok(f(item)),
-			IterStateOrCorrupted::Corrupted(..) => {
-				Err(Error::Corruption("Missing indexed value".into()))
-			},
+			IterStateOrCorrupted::Corrupted(..) =>
+				Err(Error::Corruption("Missing indexed value".into())),
 		};
 		self.iter_while_inner(log, action, 0, true)
 	}
@@ -738,7 +737,7 @@ impl HashColumn {
 						if let Ok(value) = self.compression.decompress(&value) {
 							value
 						} else {
-							return false;
+							return false
 						}
 					} else {
 						value
@@ -761,7 +760,7 @@ impl HashColumn {
 			let entries = source.entries(c, log.overlays())?;
 			for entry in entries.iter() {
 				if entry.is_empty() {
-					continue;
+					continue
 				}
 				let (size_tier, offset) = if self.db_version >= 4 {
 					let address = entry.address(source.id.index_bits());
@@ -774,21 +773,21 @@ impl HashColumn {
 					(size_tier, offset)
 				};
 
-				if skip_preimage_indexes
-					&& self.preimage && size_tier as usize != tables.value.len() - 1
+				if skip_preimage_indexes &&
+					self.preimage && size_tier as usize != tables.value.len() - 1
 				{
-					continue;
+					continue
 				}
 				let value = tables.value[size_tier as usize].get_with_meta(offset, log.overlays());
 				let (value, rc, pk, compressed) = match value {
 					Ok(Some(v)) => v,
 					Ok(None) => {
 						f(IterStateOrCorrupted::Corrupted(*entry, None))?;
-						continue;
+						continue
 					},
 					Err(e) => {
 						f(IterStateOrCorrupted::Corrupted(*entry, Some(e)))?;
-						continue;
+						continue
 					},
 				};
 				let mut key = source.recover_key_prefix(c, *entry);
@@ -806,7 +805,7 @@ impl HashColumn {
 				let state =
 					IterStateOrCorrupted::Item(IterState { chunk_index: c, key, rc, value });
 				if !f(state)? {
-					return Ok(());
+					return Ok(())
 				}
 			}
 		}
@@ -826,7 +825,7 @@ impl HashColumn {
 			|state| match state {
 				IterStateOrCorrupted::Item(IterState { chunk_index, key, rc, value }) => {
 					if Some(chunk_index) == end_chunk {
-						return Ok(false);
+						return Ok(false)
 					}
 					if chunk_index % step == 0 {
 						log::info!(target: "parity-db", "Chunk iteration at {}", chunk_index);
@@ -885,7 +884,7 @@ impl HashColumn {
 					let entries = source.entries(source_index, log.overlays())?;
 					for entry in entries.iter() {
 						if entry.is_empty() {
-							continue;
+							continue
 						}
 						// We only need key prefix to reindex.
 						let key = source.recover_key_prefix(source_index, *entry);
@@ -913,7 +912,7 @@ impl HashColumn {
 			table.unwrap().drop_file()?;
 		} else {
 			log::warn!(target: "parity-db", "Dropping invalid index {}", id);
-			return Ok(());
+			return Ok(())
 		}
 		log::debug!(target: "parity-db", "Dropped {}", id);
 		Ok(())
@@ -950,7 +949,7 @@ impl Column {
 		};
 
 		match change {
-			Operation::Reference(_) => {
+			Operation::Reference(_) =>
 				if ref_counted {
 					log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 					tables.tables[tier].write_inc_ref(address.offset(), log)?;
@@ -960,17 +959,16 @@ impl Column {
 					Ok((Some(PlanOutcome::Written), None))
 				} else {
 					Ok((Some(PlanOutcome::Skipped), None))
-				}
-			},
+				},
 			Operation::Set(_, val) => {
 				if ref_counted {
 					log::trace!(target: "parity-db", "{}: Increment ref {}", tables.col, key);
 					tables.tables[tier].write_inc_ref(address.offset(), log)?;
-					return Ok((Some(PlanOutcome::Written), None));
+					return Ok((Some(PlanOutcome::Written), None))
 				}
 				if tables.preimage {
 					// Replace is not supported
-					return Ok((Some(PlanOutcome::Skipped), None));
+					return Ok((Some(PlanOutcome::Skipped), None))
 				}
 
 				let (cval, target_tier) =

--- a/src/column.rs
+++ b/src/column.rs
@@ -4,7 +4,7 @@
 use crate::{
 	btree::BTreeTable,
 	compress::Compress,
-	db::{check::CheckDisplay, Operation, ValuePtr},
+	db::{check::CheckDisplay, Operation, RcValue},
 	display::hex,
 	error::{Error, Result},
 	index::{Address, IndexTable, PlanOutcome, TableId as IndexTableId},
@@ -498,7 +498,7 @@ impl HashColumn {
 
 	pub fn write_plan(
 		&self,
-		change: &Operation<Key, ValuePtr>,
+		change: &Operation<Key, RcValue>,
 		log: &mut LogWriter,
 	) -> Result<PlanOutcome> {
 		let tables = self.tables.upgradable_read();
@@ -535,7 +535,7 @@ impl HashColumn {
 	fn write_plan_existing(
 		&self,
 		tables: &Tables,
-		change: &Operation<Key, ValuePtr>,
+		change: &Operation<Key, RcValue>,
 		log: &mut LogWriter,
 		index: &IndexTable,
 		sub_index: usize,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1214,18 +1214,18 @@ impl CommitOverlay {
 		match &last_key {
 			LastKey::Start => self
 				.btree_indexed
-				.range::<RcValue, _>(..)
+				.range::<Vec<u8>, _>(..)
 				.next()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),
 			LastKey::End => None,
 			LastKey::At(key) => self
 				.btree_indexed
-				.range::<RcValue, _>((Bound::Excluded(key), Bound::Unbounded))
+				.range::<Vec<u8>, _>((Bound::Excluded(key), Bound::Unbounded))
 				.next()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),
 			LastKey::Seeked(key) => self
 				.btree_indexed
-				.range::<RcValue, _>(key..)
+				.range::<Value, _>(key..)
 				.next()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),
 		}
@@ -1246,13 +1246,13 @@ impl CommitOverlay {
 			LastKey::Start => None,
 			LastKey::At(key) => self
 				.btree_indexed
-				.range::<RcValue, _>(..key)
+				.range::<Vec<u8>, _>(..key)
 				.rev()
 				.next()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),
 			LastKey::Seeked(key) => self
 				.btree_indexed
-				.range::<RcValue, _>(..=key)
+				.range::<Vec<u8>, _>(..=key)
 				.rev()
 				.next()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),

--- a/src/db.rs
+++ b/src/db.rs
@@ -92,6 +92,7 @@ impl From<Value> for RcValue {
 	}
 }
 
+#[cfg(test)]
 impl<const N: usize> TryFrom<RcValue> for [u8; N] {
 	type Error = <[u8; N] as TryFrom<Vec<u8>>>::Error;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -178,7 +178,7 @@ impl DbInner {
 		if opening_mode == OpeningMode::Create {
 			try_io!(std::fs::create_dir_all(&options.path));
 		} else if !options.path.is_dir() {
-			return Err(Error::DatabaseNotFound);
+			return Err(Error::DatabaseNotFound)
 		}
 
 		let mut lock_path: std::path::PathBuf = options.path.clone();
@@ -234,7 +234,7 @@ impl DbInner {
 				let overlay = self.commit_overlay.read();
 				// Check commit overlay first
 				if let Some(v) = overlay.get(col as usize).and_then(|o| o.get(&key)) {
-					return Ok(v.map(|i| i.value().clone()));
+					return Ok(v.map(|i| i.value().clone()))
 				}
 				// Go into tables and log overlay.
 				let log = self.log.overlays();
@@ -243,7 +243,7 @@ impl DbInner {
 			Column::Tree(column) => {
 				let overlay = self.commit_overlay.read();
 				if let Some(l) = overlay.get(col as usize).and_then(|o| o.btree_get(key)) {
-					return Ok(l.map(|i| i.value().clone()));
+					return Ok(l.map(|i| i.value().clone()))
 				}
 				// We lock log, if btree structure changed while reading that would be an issue.
 				let log = self.log.overlays().read();
@@ -259,7 +259,7 @@ impl DbInner {
 				let overlay = self.commit_overlay.read();
 				// Check commit overlay first
 				if let Some(l) = overlay.get(col as usize).and_then(|o| o.get_size(&key)) {
-					return Ok(l);
+					return Ok(l)
 				}
 				// Go into tables and log overlay.
 				let log = self.log.overlays();
@@ -268,7 +268,7 @@ impl DbInner {
 			Column::Tree(column) => {
 				let overlay = self.commit_overlay.read();
 				if let Some(l) = overlay.get(col as usize).and_then(|o| o.btree_get(key)) {
-					return Ok(l.map(|v| v.value().len() as u32));
+					return Ok(l.map(|v| v.value().len() as u32))
 				}
 				let log = self.log.overlays().read();
 				let l = column.with_locked(|btree| BTreeTable::get(key, &*log, btree))?;
@@ -279,9 +279,8 @@ impl DbInner {
 
 	fn btree_iter(&self, col: ColId) -> Result<BTreeIterator> {
 		match &self.columns[col as usize] {
-			Column::Hash(_column) => {
-				Err(Error::InvalidConfiguration("Not an indexed column.".to_string()))
-			},
+			Column::Hash(_column) =>
+				Err(Error::InvalidConfiguration("Not an indexed column.".to_string())),
 			Column::Tree(column) => {
 				let log = self.log.overlays();
 				BTreeIterator::new(column, col, log, &self.commit_overlay)
@@ -346,7 +345,7 @@ impl DbInner {
 		{
 			let bg_err = self.bg_err.lock();
 			if let Some(err) = &*bg_err {
-				return Err(Error::Background(err.clone()));
+				return Err(Error::Background(err.clone()))
 			}
 		}
 
@@ -411,8 +410,8 @@ impl DbInner {
 					commit.bytes,
 					queue.bytes,
 				);
-				if queue.bytes <= MAX_COMMIT_QUEUE_BYTES
-					&& (queue.bytes + commit.bytes) > MAX_COMMIT_QUEUE_BYTES
+				if queue.bytes <= MAX_COMMIT_QUEUE_BYTES &&
+					(queue.bytes + commit.bytes) > MAX_COMMIT_QUEUE_BYTES
 				{
 					// Past the waiting threshold.
 					log::debug!(
@@ -449,11 +448,10 @@ impl DbInner {
 
 			for (c, btree) in commit.changeset.btree_indexed.iter_mut() {
 				match &self.columns[*c as usize] {
-					Column::Hash(_column) => {
+					Column::Hash(_column) =>
 						return Err(Error::InvalidConfiguration(
 							"Not an indexed column.".to_string(),
-						))
-					},
+						)),
 					Column::Tree(column) => {
 						btree.write_plan(column, &mut writer, &mut ops)?;
 					},
@@ -512,7 +510,7 @@ impl DbInner {
 	fn process_reindex(&self) -> Result<bool> {
 		let next_reindex = self.next_reindex.load(Ordering::SeqCst);
 		if next_reindex == 0 || next_reindex > self.last_enacted.load(Ordering::SeqCst) {
-			return Ok(false);
+			return Ok(false)
 		}
 		// Process any pending reindexes
 		for column in self.columns.iter() {
@@ -552,7 +550,7 @@ impl DbInner {
 					self.start_reindex(record_id);
 				}
 				self.flush_worker_wait.signal();
-				return Ok(true);
+				return Ok(true)
 			}
 		}
 		self.next_reindex.store(0, Ordering::SeqCst);
@@ -566,7 +564,7 @@ impl DbInner {
 				Err(Error::Corruption(_)) if validation_mode => {
 					log::debug!(target: "parity-db", "Bad log header");
 					self.log.clear_replay_logs();
-					return Ok(false);
+					return Ok(false)
 				},
 				Err(e) => return Err(e),
 			};
@@ -586,7 +584,7 @@ impl DbInner {
 						);
 						drop(reader);
 						self.log.clear_replay_logs();
-						return Ok(false);
+						return Ok(false)
 					}
 					// Validate all records before applying anything
 					loop {
@@ -596,7 +594,7 @@ impl DbInner {
 								log::debug!(target: "parity-db", "Error reading log: {:?}", e);
 								drop(reader);
 								self.log.clear_replay_logs();
-								return Ok(false);
+								return Ok(false)
 							},
 						};
 						match next {
@@ -604,7 +602,7 @@ impl DbInner {
 								log::debug!(target: "parity-db", "Unexpected log header");
 								drop(reader);
 								self.log.clear_replay_logs();
-								return Ok(false);
+								return Ok(false)
 							},
 							LogAction::EndRecord => break,
 							LogAction::InsertIndex(insertion) => {
@@ -621,7 +619,7 @@ impl DbInner {
 									log::warn!(target: "parity-db", "Error replaying log: {:?}. Reverting", e);
 									drop(reader);
 									self.log.clear_replay_logs();
-									return Ok(false);
+									return Ok(false)
 								}
 							},
 							LogAction::InsertValue(insertion) => {
@@ -638,7 +636,7 @@ impl DbInner {
 									log::warn!(target: "parity-db", "Error replaying log: {:?}. Reverting", e);
 									drop(reader);
 									self.log.clear_replay_logs();
-									return Ok(false);
+									return Ok(false)
 								}
 							},
 							LogAction::DropTable(_) => continue,
@@ -649,9 +647,8 @@ impl DbInner {
 				}
 				loop {
 					match reader.next()? {
-						LogAction::BeginRecord => {
-							return Err(Error::Corruption("Bad log record".into()))
-						},
+						LogAction::BeginRecord =>
+							return Err(Error::Corruption("Bad log record".into())),
 						LogAction::EndRecord => break,
 						LogAction::InsertIndex(insertion) => {
 							self.columns[insertion.table.col() as usize]
@@ -711,8 +708,8 @@ impl DbInner {
 						);
 					}
 					*queue -= bytes as i64;
-					if *queue <= MAX_LOG_QUEUE_BYTES
-						&& (*queue + bytes as i64) > MAX_LOG_QUEUE_BYTES
+					if *queue <= MAX_LOG_QUEUE_BYTES &&
+						(*queue + bytes as i64) > MAX_LOG_QUEUE_BYTES
 					{
 						self.log_queue_wait.cv.notify_one();
 					}
@@ -786,7 +783,7 @@ impl DbInner {
 				// to no attempt any further log enactment.
 				log::debug!(target: "parity-db", "Shutdown with error state {}", err);
 				self.log.clean_logs(self.log.num_dirty_logs())?;
-				return self.log.kill_logs();
+				return self.log.kill_logs()
 			}
 		}
 		log::debug!(target: "parity-db", "Processing leftover commits");
@@ -900,7 +897,7 @@ impl Db {
 			log::debug!(target: "parity-db", "Error during log replay, doing log cleanup");
 			db.log.clean_logs(db.log.num_dirty_logs())?;
 			db.log.kill_logs()?;
-			return Err(e);
+			return Err(e)
 		}
 		let db = Arc::new(db);
 		#[cfg(any(test, feature = "instrumentation"))]
@@ -1377,7 +1374,7 @@ impl IndexedChangeSet {
 					// Don't add (we allow remove value in overlay when using rc: some
 					// indexing on top of it is expected).
 					if !ref_counted {
-						return Err(Error::InvalidInput(format!("No Rc for column {}", self.col)));
+						return Err(Error::InvalidInput(format!("No Rc for column {}", self.col)))
 					}
 				},
 			}
@@ -1396,7 +1393,7 @@ impl IndexedChangeSet {
 			Column::Hash(column) => column,
 			Column::Tree(_) => {
 				log::warn!(target: "parity-db", "Skipping unindex commit in indexed column");
-				return Ok(());
+				return Ok(())
 			},
 		};
 		for change in self.changes.iter() {
@@ -1518,8 +1515,8 @@ mod tests {
 
 		fn run_stages(&self, db: &Db) {
 			let db = &db.inner;
-			if *self == EnableCommitPipelineStages::DbFile
-				|| *self == EnableCommitPipelineStages::LogOverlay
+			if *self == EnableCommitPipelineStages::DbFile ||
+				*self == EnableCommitPipelineStages::LogOverlay
 			{
 				while db.process_commits().unwrap() {}
 				while db.process_reindex().unwrap() {}
@@ -1546,7 +1543,7 @@ mod tests {
 									// or removed.
 									std::thread::sleep(std::time::Duration::from_millis(100));
 								} else {
-									return false;
+									return false
 								}
 							}
 						}
@@ -2078,20 +2075,18 @@ mod tests {
 				let mut remove = false;
 				let mut insert = false;
 				match state.get_mut(k) {
-					Some(Some((_, counter))) => {
+					Some(Some((_, counter))) =>
 						if v.is_some() {
 							*counter += 1;
 						} else if *counter == 1 {
 							remove = true;
 						} else {
 							*counter -= 1;
-						}
-					},
-					Some(None) | None => {
+						},
+					Some(None) | None =>
 						if v.is_some() {
 							insert = true;
-						}
-					},
+						},
 				}
 				if insert {
 					state.insert(k.clone(), v.clone().map(|v| (v, 1)));

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,8 +29,9 @@ impl fmt::Display for Error {
 			Error::Io(e) => write!(f, "IO Error: {e}"),
 			Error::Corruption(e) => write!(f, "Corruption: {e}"),
 			Error::InvalidConfiguration(e) => write!(f, "Invalid configuration: {e}"),
-			Error::IncompatibleColumnConfig { id, reason } =>
-				write!(f, "Invalid column {id} configuration : {reason}"),
+			Error::IncompatibleColumnConfig { id, reason } => {
+				write!(f, "Invalid column {id} configuration : {reason}")
+			},
 			Error::InvalidInput(e) => write!(f, "Invalid input: {e}"),
 			Error::InvalidValueData => write!(f, "Invalid data in value table"),
 			Error::Background(e) => write!(f, "Background worker error: {e}"),

--- a/src/log.rs
+++ b/src/log.rs
@@ -203,7 +203,7 @@ impl<'a> LogReader<'a> {
 						expected,
 					);
 					if checksum != expected {
-						return Err(Error::Corruption("Log record CRC-32 mismatch".into()))
+						return Err(Error::Corruption("Log record CRC-32 mismatch".into()));
 					}
 				} else {
 					log::trace!(target: "parity-db", "Read end of record");
@@ -538,7 +538,7 @@ impl Log {
 	pub fn open_log_file(path: &std::path::Path) -> Result<(std::fs::File, Option<u64>)> {
 		let mut file = try_io!(std::fs::OpenOptions::new().read(true).write(true).open(path));
 		if try_io!(file.metadata()).len() == 0 {
-			return Ok((file, None))
+			return Ok((file, None));
 		}
 		match Self::read_first_record_id(&mut file) {
 			Err(Error::Io(e)) if e.kind() == ErrorKind::UnexpectedEof => {
@@ -547,7 +547,7 @@ impl Log {
 			},
 			Err(e) => Err(e),
 			Ok(id) => {
-				try_io!(file.seek(std::io::SeekFrom::Start(0)));
+				try_io!(file.rewind());
 				log::debug!(target: "parity-db", "Opened existing log {}, first record_id = {}", path.display(), id);
 				Ok((file, Some(id)))
 			},
@@ -676,7 +676,7 @@ impl Log {
 				}
 				self.read_queue.write().push_back((to_flush.id, file));
 			}
-			return Ok(true)
+			return Ok(true);
 		}
 		Ok(false)
 	}
@@ -707,7 +707,7 @@ impl Log {
 		};
 		for (id, ref mut file) in cleaned.iter_mut() {
 			log::debug!(target: "parity-db", "Cleaned: {}", id);
-			try_io!(file.seek(std::io::SeekFrom::Start(0)));
+			try_io!(file.rewind());
 			try_io!(file.set_len(0));
 		}
 		// Move cleaned logs back to the pool
@@ -733,11 +733,11 @@ impl Log {
 		let mut reading = self.reading.write();
 		if reading.is_none() {
 			if let Some((id, mut file)) = self.read_queue.write().pop_front() {
-				try_io!(file.seek(std::io::SeekFrom::Start(0)));
+				try_io!(file.rewind());
 				*reading = Some(Reading { id, file: std::io::BufReader::new(file) });
 			} else {
 				log::trace!(target: "parity-db", "No active reader");
-				return Ok(None)
+				return Ok(None);
 			}
 		}
 		let mut reader = LogReader::new(reading, validate);

--- a/src/log.rs
+++ b/src/log.rs
@@ -203,7 +203,7 @@ impl<'a> LogReader<'a> {
 						expected,
 					);
 					if checksum != expected {
-						return Err(Error::Corruption("Log record CRC-32 mismatch".into()));
+						return Err(Error::Corruption("Log record CRC-32 mismatch".into()))
 					}
 				} else {
 					log::trace!(target: "parity-db", "Read end of record");
@@ -538,7 +538,7 @@ impl Log {
 	pub fn open_log_file(path: &std::path::Path) -> Result<(std::fs::File, Option<u64>)> {
 		let mut file = try_io!(std::fs::OpenOptions::new().read(true).write(true).open(path));
 		if try_io!(file.metadata()).len() == 0 {
-			return Ok((file, None));
+			return Ok((file, None))
 		}
 		match Self::read_first_record_id(&mut file) {
 			Err(Error::Io(e)) if e.kind() == ErrorKind::UnexpectedEof => {
@@ -676,7 +676,7 @@ impl Log {
 				}
 				self.read_queue.write().push_back((to_flush.id, file));
 			}
-			return Ok(true);
+			return Ok(true)
 		}
 		Ok(false)
 	}
@@ -737,7 +737,7 @@ impl Log {
 				*reading = Some(Reading { id, file: std::io::BufReader::new(file) });
 			} else {
 				log::trace!(target: "parity-db", "No active reader");
-				return Ok(None);
+				return Ok(None)
 			}
 		}
 		let mut reader = LogReader::new(reading, validate);

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -31,14 +31,14 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 		to_migrate.insert(*force);
 	}
 	if source_meta.columns.len() != to.columns.len() {
-		return Err(Error::Migration("Source and dest columns mismatch".into()));
+		return Err(Error::Migration("Source and dest columns mismatch".into()))
 	}
 
 	// Make sure we are using the same salt value.
 	to.salt = Some(source_meta.salt);
 
 	if (to.salt.is_none()) && overwrite {
-		return Err(Error::Migration("Changing salt need to update metadata at once.".into()));
+		return Err(Error::Migration("Changing salt need to update metadata at once.".into()))
 	}
 
 	let mut source_options = Options::with_columns(from, source_meta.columns.len() as u8);
@@ -62,7 +62,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 		if source_options.columns[*c as usize].btree_index || to.columns[*c as usize].btree_index {
 			return Err(Error::Migration(
 				"Migrate only implemented for hash indexed column to hash indexed column".into(),
-			));
+			))
 		}
 	}
 
@@ -73,7 +73,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 				copy_column(c, from, &to.path)?;
 				dest = Db::open_or_create(&to)?;
 			}
-			continue;
+			continue
 		}
 		log::info!("Migrating col {}", c);
 		source.iter_column_while(c, |IterState { chunk_index: index, key, rc, mut value }| {
@@ -91,7 +91,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 					ncommits += 1;
 					if let Err(e) = dest.commit_raw(std::mem::take(&mut commit)) {
 						log::warn!("Migration error: {:?}", e);
-						return false;
+						return false
 					}
 					nb_commit = 0;
 
@@ -157,7 +157,7 @@ pub fn clear_column(path: &Path, column: ColId) -> Result<()> {
 		.ok_or_else(|| Error::Migration("Error loading source metadata".into()))?;
 
 	if (column as usize) >= meta.columns.len() {
-		return Err(Error::Migration("Invalid column index".into()));
+		return Err(Error::Migration("Invalid column index".into()))
 	}
 
 	// Validate the database by opening. This also makes sure all the logs are enacted,
@@ -174,8 +174,8 @@ pub fn clear_column(path: &Path, column: ColId) -> Result<()> {
 	for entry in try_io!(std::fs::read_dir(path)) {
 		let entry = try_io!(entry);
 		if let Some(file) = entry.path().file_name().and_then(|f| f.to_str()) {
-			if crate::index::TableId::is_file_name(column, file)
-				|| crate::table::TableId::is_file_name(column, file)
+			if crate::index::TableId::is_file_name(column, file) ||
+				crate::table::TableId::is_file_name(column, file)
 			{
 				to_delete.push(PathBuf::from(file));
 			}
@@ -202,8 +202,8 @@ fn deplace_column(c: ColId, from: &Path, to: &Path, copy: bool) -> Result<()> {
 	for entry in try_io!(std::fs::read_dir(from)) {
 		let entry = try_io!(entry);
 		if let Some(file) = entry.path().file_name().and_then(|f| f.to_str()) {
-			if crate::index::TableId::is_file_name(c, file)
-				|| crate::table::TableId::is_file_name(c, file)
+			if crate::index::TableId::is_file_name(c, file) ||
+				crate::table::TableId::is_file_name(c, file)
 			{
 				let mut from = from.to_path_buf();
 				from.push(file);

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -31,14 +31,14 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 		to_migrate.insert(*force);
 	}
 	if source_meta.columns.len() != to.columns.len() {
-		return Err(Error::Migration("Source and dest columns mismatch".into()))
+		return Err(Error::Migration("Source and dest columns mismatch".into()));
 	}
 
 	// Make sure we are using the same salt value.
 	to.salt = Some(source_meta.salt);
 
 	if (to.salt.is_none()) && overwrite {
-		return Err(Error::Migration("Changing salt need to update metadata at once.".into()))
+		return Err(Error::Migration("Changing salt need to update metadata at once.".into()));
 	}
 
 	let mut source_options = Options::with_columns(from, source_meta.columns.len() as u8);
@@ -62,7 +62,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 		if source_options.columns[*c as usize].btree_index || to.columns[*c as usize].btree_index {
 			return Err(Error::Migration(
 				"Migrate only implemented for hash indexed column to hash indexed column".into(),
-			))
+			));
 		}
 	}
 
@@ -73,7 +73,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 				copy_column(c, from, &to.path)?;
 				dest = Db::open_or_create(&to)?;
 			}
-			continue
+			continue;
 		}
 		log::info!("Migrating col {}", c);
 		source.iter_column_while(c, |IterState { chunk_index: index, key, rc, mut value }| {
@@ -85,13 +85,13 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 					.entry(c)
 					.or_insert_with(|| IndexedChangeSet::new(c))
 					.changes
-					.push(Operation::Set(key, value));
+					.push(Operation::Set(key, value.into()));
 				nb_commit += 1;
 				if nb_commit == COMMIT_SIZE {
 					ncommits += 1;
 					if let Err(e) = dest.commit_raw(std::mem::take(&mut commit)) {
 						log::warn!("Migration error: {:?}", e);
-						return false
+						return false;
 					}
 					nb_commit = 0;
 
@@ -157,7 +157,7 @@ pub fn clear_column(path: &Path, column: ColId) -> Result<()> {
 		.ok_or_else(|| Error::Migration("Error loading source metadata".into()))?;
 
 	if (column as usize) >= meta.columns.len() {
-		return Err(Error::Migration("Invalid column index".into()))
+		return Err(Error::Migration("Invalid column index".into()));
 	}
 
 	// Validate the database by opening. This also makes sure all the logs are enacted,
@@ -174,8 +174,8 @@ pub fn clear_column(path: &Path, column: ColId) -> Result<()> {
 	for entry in try_io!(std::fs::read_dir(path)) {
 		let entry = try_io!(entry);
 		if let Some(file) = entry.path().file_name().and_then(|f| f.to_str()) {
-			if crate::index::TableId::is_file_name(column, file) ||
-				crate::table::TableId::is_file_name(column, file)
+			if crate::index::TableId::is_file_name(column, file)
+				|| crate::table::TableId::is_file_name(column, file)
 			{
 				to_delete.push(PathBuf::from(file));
 			}
@@ -202,8 +202,8 @@ fn deplace_column(c: ColId, from: &Path, to: &Path, copy: bool) -> Result<()> {
 	for entry in try_io!(std::fs::read_dir(from)) {
 		let entry = try_io!(entry);
 		if let Some(file) = entry.path().file_name().and_then(|f| f.to_str()) {
-			if crate::index::TableId::is_file_name(c, file) ||
-				crate::table::TableId::is_file_name(c, file)
+			if crate::index::TableId::is_file_name(c, file)
+				|| crate::table::TableId::is_file_name(c, file)
 			{
 				let mut from = from.to_path_buf();
 				from.push(file);


### PR DESCRIPTION
I notice that the `copy_to_overlay` method clones the `value` vector in Hash index mode and clones both the `key` and `value` vectors in Btree index mode, which seems to be an unnecessary overhead, this PR tries to, instead, clone the pointer type `Arc<Vec<u8>>` which is much cheaper, please let me know your feedback, thanks!