### PR TITLE
feat: find_entry simd optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ instrumentation = []
 
 [dependencies]
 blake2 = "0.10.4"
+cfg-if = "1"
 crc32fast = "1.2.0"
 fs2 = "0.4.3"
 hex = "0.4.2"
@@ -30,6 +31,9 @@ env_logger = "0.9.0"
 fdlimit = "0.2.1"
 rand = { version = "0.8.2", features = ["small_rng"] }
 tempfile = "3.2"
+
+[build-dependencies]
+rustc_version = "0.4"
 
 [profile.release]
 panic = "abort"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+	match version_meta().unwrap().channel {
+		Channel::Nightly => println!("cargo:rustc-cfg=nightly"),
+		Channel::Beta => println!("cargo:rustc-cfg=beta"),
+		_ => {},
+	};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright 2021-2022 Parity Technologies (UK) Ltd.
 // This file is dual-licensed as Apache-2.0 or MIT.
 
+#![cfg_attr(nightly, feature(portable_simd))]
+#![cfg_attr(nightly, feature(test))]
+
 mod btree;
 mod column;
 mod compress;


### PR DESCRIPTION
This PR tries to address https://github.com/paritytech/parity-db/issues/171 by using [std::simd](https://doc.rust-lang.org/nightly/std/simd/) on nightly rust.

My local stress test results:
`RUSTFLAGS="-Ctarget-feature=+avx2" cargo +nightly run -p parity-db-admin --release -- stress`
```
sse2
Completed 100000 commits in 70.011662619 seconds. 1428.3334555871788 cps. 0 hits, 0 misses, 0 iterations, 0 qps
Completed 10000000 queries in 6.168205102 seconds. 1621217.1668477051 qps

base
Completed 100000 commits in 62.011042791 seconds. 1612.616003524352 cps. 0 hits, 0 misses, 0 iterations, 0 qps
Completed 10000000 queries in 5.826384161 seconds. 1716330.3557868504 qps

base_simd 2 lanes
Completed 100000 commits in 66.00952211 seconds. 1514.9329491184221 cps. 0 hits, 0 misses, 0 iterations, 0 qps
Completed 10000000 queries in 5.915917492 seconds. 1690354.8796146733 qps

base_simd 4 lanes
Completed 100000 commits in 63.01187526 seconds. 1587.0024433867327 cps. 0 hits, 0 misses, 0 iterations, 0 qps
Completed 10000000 queries in 5.814712547 seconds. 1719775.4694098036 qps
```