### PR TITLE
Benchmarks for find_entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Key-value database for the blockchain"
 
 [features]
 instrumentation = []
+bench = []
 
 [dependencies]
 blake2 = "0.10.4"

--- a/src/index.rs
+++ b/src/index.rs
@@ -237,7 +237,6 @@ impl IndexTable {
 		Ok(try_io!(Ok(ptr)))
 	}
 
-	#[inline(always)]
 	#[cfg(target_feature = "sse2")]
 	fn find_entry(
 		&self,

--- a/src/index.rs
+++ b/src/index.rs
@@ -230,9 +230,10 @@ impl IndexTable {
 		Ok(())
 	}
 
-	fn chunk_at(index: u64, map: &memmap2::MmapMut) -> Result<&[u8]> {
+	fn chunk_at(index: u64, map: &memmap2::MmapMut) -> Result<&[u8; CHUNK_LEN]> {
 		let offset = META_SIZE + index as usize * CHUNK_LEN;
-		Ok(try_io!(Ok(&map[offset..offset + CHUNK_LEN])))
+		let ptr: &[u8; CHUNK_LEN] = unsafe { std::mem::transmute(map[offset..offset + CHUNK_LEN].as_ptr()) };
+		Ok(try_io!(Ok(ptr)))
 	}
 
 	fn find_entry(&self, key_prefix: u64, sub_index: usize, chunk: &[u8]) -> (Entry, usize) {
@@ -360,7 +361,7 @@ impl IndexTable {
 	}
 
 	#[inline(always)]
-	fn read_entry(chunk: &[u8], at: usize) -> Entry {
+	fn read_entry(chunk: &[u8; CHUNK_LEN], at: usize) -> Entry {
 		Entry::from_u64(u64::from_le_bytes(chunk[at * 8..at * 8 + 8].try_into().unwrap()))
 	}
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -259,7 +259,12 @@ impl IndexTable {
 	}
 
 	#[cfg(target_feature = "sse2")]
-	fn find_entry_sse2(&self, key_prefix: u64, sub_index: usize, chunk: &[u8; CHUNK_LEN]) -> (Entry, usize) {
+	fn find_entry_sse2(
+		&self,
+		key_prefix: u64,
+		sub_index: usize,
+		chunk: &[u8; CHUNK_LEN],
+	) -> (Entry, usize) {
 		assert!(chunk.len() >= CHUNK_ENTRIES * 8); // Bound checking (not done by SIMD instructions)
 		const _: () = assert!(
 			CHUNK_ENTRIES % 4 == 0,

--- a/src/index.rs
+++ b/src/index.rs
@@ -259,7 +259,7 @@ impl IndexTable {
 	}
 
 	#[cfg(target_feature = "sse2")]
-	fn find_entry_sse2(&self, key_prefix: u64, sub_index: usize, chunk: &[u8]) -> (Entry, usize) {
+	fn find_entry_sse2(&self, key_prefix: u64, sub_index: usize, chunk: &[u8; CHUNK_LEN]) -> (Entry, usize) {
 		assert!(chunk.len() >= CHUNK_ENTRIES * 8); // Bound checking (not done by SIMD instructions)
 		const _: () = assert!(
 			CHUNK_ENTRIES % 4 == 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2021-2022 Parity Technologies (UK) Ltd.
 // This file is dual-licensed as Apache-2.0 or MIT.
 
+#![cfg_attr(feature = "bench", feature(test))]
+
 mod btree;
 mod column;
 mod compress;


### PR DESCRIPTION
```
$ cargo +nightly bench --features bench bench
    Finished bench [optimized + debuginfo] target(s) in 0.06s
     Running unittests src/lib.rs (target/release/deps/parity_db-21d11d42e7884130)

running 2 tests
test index::test::bench_find_entry     ... bench:          29 ns/iter (+/- 0)
test index::test::bench_find_entry_sse ... bench:          13 ns/iter (+/- 0)
```

Also added a small optimization for `chunk_at`