### PR TITLE
Preserve logs on write error. 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,7 @@ jobs:
           args: --test loom --features=loom,instrumentation --release --verbose
         env:
           LOOM_MAX_PREEMPTIONS: 3
+          LOOM_MAX_BRANCHES: 2000
 
   test_aarch64:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/column.rs
+++ b/src/column.rs
@@ -443,7 +443,7 @@ impl HashColumn {
 		while let PlanOutcome::NeedReindex =
 			tables.index.write_insert_plan(key, address, None, log)?
 		{
-			log::info!(target: "parity-db", "{}: Index chunk full {} when reindexing", tables.index.id, hex(key));
+			log::debug!(target: "parity-db", "{}: Index chunk full {} when reindexing", tables.index.id, hex(key));
 			(tables, reindex) = Self::trigger_reindex(tables, reindex, self.path.as_path());
 			outcome = PlanOutcome::NeedReindex;
 		}

--- a/src/db.rs
+++ b/src/db.rs
@@ -786,7 +786,7 @@ impl DbInner {
 				// to no attempt any further log enactment.
 				log::debug!(target: "parity-db", "Shutdown with error state {}", err);
 				self.log.clean_logs(self.log.num_dirty_logs())?;
-				return Ok(());
+				return Ok(())
 			}
 		}
 		log::debug!(target: "parity-db", "Processing leftover commits");
@@ -942,13 +942,7 @@ impl Db {
 		} else {
 			None
 		};
-		Ok(Db {
-			inner: db,
-			commit_thread,
-			flush_thread,
-			log_thread,
-			cleanup_thread,
-		})
+		Ok(Db { inner: db, commit_thread, flush_thread, log_thread, cleanup_thread })
 	}
 
 	/// Get a value in a specified column by key. Returns `None` if the key does not exist.

--- a/src/db.rs
+++ b/src/db.rs
@@ -786,7 +786,7 @@ impl DbInner {
 				// to no attempt any further log enactment.
 				log::debug!(target: "parity-db", "Shutdown with error state {}", err);
 				self.log.clean_logs(self.log.num_dirty_logs())?;
-				return self.log.kill_logs()
+				return Ok(());
 			}
 		}
 		log::debug!(target: "parity-db", "Processing leftover commits");
@@ -867,7 +867,6 @@ pub struct Db {
 	flush_thread: Option<thread::JoinHandle<()>>,
 	log_thread: Option<thread::JoinHandle<()>>,
 	cleanup_thread: Option<thread::JoinHandle<()>>,
-	join_on_shutdown: bool,
 }
 
 impl Db {
@@ -949,7 +948,6 @@ impl Db {
 			flush_thread,
 			log_thread,
 			cleanup_thread,
-			join_on_shutdown: start_threads,
 		})
 	}
 
@@ -1140,31 +1138,29 @@ impl Db {
 
 impl Drop for Db {
 	fn drop(&mut self) {
-		if self.join_on_shutdown {
-			self.inner.shutdown();
-			if let Some(t) = self.log_thread.take() {
-				if let Err(e) = t.join() {
-					log::warn!(target: "parity-db", "Log thread shutdown error: {:?}", e);
-				}
+		self.inner.shutdown();
+		if let Some(t) = self.log_thread.take() {
+			if let Err(e) = t.join() {
+				log::warn!(target: "parity-db", "Log thread shutdown error: {:?}", e);
 			}
-			if let Some(t) = self.flush_thread.take() {
-				if let Err(e) = t.join() {
-					log::warn!(target: "parity-db", "Flush thread shutdown error: {:?}", e);
-				}
+		}
+		if let Some(t) = self.flush_thread.take() {
+			if let Err(e) = t.join() {
+				log::warn!(target: "parity-db", "Flush thread shutdown error: {:?}", e);
 			}
-			if let Some(t) = self.commit_thread.take() {
-				if let Err(e) = t.join() {
-					log::warn!(target: "parity-db", "Commit thread shutdown error: {:?}", e);
-				}
+		}
+		if let Some(t) = self.commit_thread.take() {
+			if let Err(e) = t.join() {
+				log::warn!(target: "parity-db", "Commit thread shutdown error: {:?}", e);
 			}
-			if let Some(t) = self.cleanup_thread.take() {
-				if let Err(e) = t.join() {
-					log::warn!(target: "parity-db", "Cleanup thread shutdown error: {:?}", e);
-				}
+		}
+		if let Some(t) = self.cleanup_thread.take() {
+			if let Err(e) = t.join() {
+				log::warn!(target: "parity-db", "Cleanup thread shutdown error: {:?}", e);
 			}
-			if let Err(e) = self.inner.kill_logs() {
-				log::warn!(target: "parity-db", "Shutdown error: {:?}", e);
-			}
+		}
+		if let Err(e) = self.inner.kill_logs() {
+			log::warn!(target: "parity-db", "Shutdown error: {:?}", e);
 		}
 	}
 }
@@ -2447,6 +2443,41 @@ mod tests {
 		for _ in 0..100 {
 			let next = iter.prev().unwrap();
 			assert_eq!(iter_state_rev.next(), next.as_ref().map(|(k, v)| (k, v)));
+		}
+	}
+
+	#[cfg(feature = "instrumentation")]
+	#[test]
+	fn test_recover_from_log_on_error() {
+		let tmp = tempdir().unwrap();
+		let mut options = Options::with_columns(tmp.path(), 1);
+		options.always_flush = true;
+		options.with_background_thread = false;
+
+		// We do 2 commits and we fail while enacting the second one
+		{
+			let db = Db::open_or_create(&options).unwrap();
+			db.commit::<_, Vec<u8>>(vec![(0, vec![0], Some(vec![0]))]).unwrap();
+			db.process_commits().unwrap();
+			db.flush_logs().unwrap();
+			db.enact_logs().unwrap();
+			db.commit::<_, Vec<u8>>(vec![(0, vec![1], Some(vec![1]))]).unwrap();
+			db.process_commits().unwrap();
+			db.flush_logs().unwrap();
+			crate::set_number_of_allowed_io_operations(4);
+
+			// Set the background error explicitly as background threads are disabled in tests.
+			let err = db.enact_logs();
+			assert!(err.is_err());
+			db.inner.store_err(err);
+			crate::set_number_of_allowed_io_operations(usize::MAX);
+		}
+
+		// Open the databases and check that both values are there.
+		{
+			let db = Db::open(&options).unwrap();
+			assert_eq!(db.get(0, &[0]).unwrap(), Some(vec![0]));
+			assert_eq!(db.get(0, &[1]).unwrap(), Some(vec![1]));
 		}
 	}
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -430,7 +430,7 @@ impl IndexTable {
 				return Ok(PlanOutcome::Written)
 			}
 		}
-		log::trace!(target: "parity-db", "{}: Index chunk full at {}", self.id, chunk_index);
+		log::debug!(target: "parity-db", "{}: Index chunk full at {}", self.id, chunk_index);
 		Ok(PlanOutcome::NeedReindex)
 	}
 


### PR DESCRIPTION
This fixes a potential DB corruption on write error. When the database is closed with an error, all existing logs must be preserved so that log recovery may fix it on next open.