### PR TITLE
Fix find_entry_sse

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -23,8 +23,8 @@ const CHUNK_ENTRIES: usize = 1 << CHUNK_ENTRIES_BITS;
 const CHUNK_ENTRIES_BITS: u8 = 6;
 const HEADER_SIZE: usize = 512;
 const META_SIZE: usize = 16 * 1024; // Contains header and column stats
-const ENTRY_LEN: u8 = 64;
-pub const ENTRY_BYTES: usize = ENTRY_LEN as usize / 8;
+const ENTRY_BITS: u8 = 64;
+pub const ENTRY_BYTES: usize = ENTRY_BITS as usize / 8;
 
 const EMPTY_CHUNK: Chunk = [0u8; CHUNK_LEN];
 
@@ -389,7 +389,7 @@ impl IndexTable {
 
 	#[inline(always)]
 	fn chunk_index(&self, key_prefix: u64) -> u64 {
-		key_prefix >> (ENTRY_LEN - self.id.index_bits())
+		key_prefix >> (ENTRY_BITS - self.id.index_bits())
 	}
 
 	fn plan_insert_chunk(
@@ -607,13 +607,11 @@ impl IndexTable {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use rand::{Rng, SeedableRng};
 	use std::path::PathBuf;
 
 	#[cfg(feature = "bench")]
-	use {
-		rand::{Rng, SeedableRng},
-		test::Bencher,
-	};
+	use test::Bencher;
 	#[cfg(feature = "bench")]
 	extern crate test;
 
@@ -671,6 +669,66 @@ mod test {
 		}
 	}
 
+	#[test]
+	fn test_find_any_entry() {
+		let table =
+			IndexTable { id: TableId(18), map: RwLock::new(None), path: Default::default() };
+		let mut chunk = [0u8; CHUNK_LEN];
+		let mut entries = [Entry::empty(); CHUNK_ENTRIES];
+		let mut keys = [0u64; CHUNK_ENTRIES];
+		let mut rng = rand::prelude::SmallRng::from_seed(Default::default());
+		for i in 0..CHUNK_ENTRIES {
+			keys[i] = rng.gen();
+			let partial_key = Entry::extract_key(keys[i], 18);
+			let e = Entry::new(Address::new(0, 0), partial_key, 18);
+			entries[i] = e;
+			IndexTable::write_entry(&e, i, &mut chunk);
+		}
+
+		for target in 0..CHUNK_ENTRIES {
+			for start_pos in 0..CHUNK_ENTRIES {
+				let (e, i) = table.find_entry_base(keys[target], start_pos, &chunk);
+				if start_pos <= target {
+					assert_eq!((e.as_u64(), i), (entries[target].as_u64(), target));
+				} else {
+					assert_eq!((e.as_u64(), i), (Entry::empty().as_u64(), 0));
+				}
+				#[cfg(target_arch = "x86_64")]
+				{
+					let (e, i) = table.find_entry_sse2(keys[target], start_pos, &chunk);
+					if start_pos <= target {
+						assert_eq!((e.as_u64(), i), (entries[target].as_u64(), target));
+					} else {
+						assert_eq!((e.as_u64(), i), (Entry::empty().as_u64(), 0));
+					}
+				}
+			}
+		}
+	}
+
+	#[test]
+	fn test_find_any_entry_same_value() {
+		let table =
+			IndexTable { id: TableId(18), map: RwLock::new(None), path: Default::default() };
+		let mut chunk = [0u8; CHUNK_LEN];
+		let key = 0x4242424242424242;
+		let partial_key = Entry::extract_key(key, 18);
+		let entry = Entry::new(Address::new(0, 0), partial_key, 18);
+		for i in 0..CHUNK_ENTRIES {
+			IndexTable::write_entry(&entry, i, &mut chunk);
+		}
+
+		for start_pos in 0..CHUNK_ENTRIES {
+			let (_, i) = table.find_entry_base(key, start_pos, &chunk);
+			assert_eq!(i, start_pos);
+			#[cfg(target_arch = "x86_64")]
+			{
+				let (_, i) = table.find_entry_sse2(key, start_pos, &chunk);
+				assert_eq!(i, start_pos);
+			}
+		}
+	}
+
 	#[cfg(feature = "bench")]
 	fn bench_find_entry_internal<
 		F: Fn(&IndexTable, u64, usize, &[u8; CHUNK_LEN]) -> (Entry, usize),
@@ -680,10 +738,10 @@ mod test {
 	) {
 		let table =
 			IndexTable { id: TableId(18), map: RwLock::new(None), path: Default::default() };
-		let mut chunk = [0u8; 512];
-		let mut keys = [0u64; 64];
+		let mut chunk = [0u8; CHUNK_LEN];
+		let mut keys = [0u64; CHUNK_ENTRIES];
 		let mut rng = rand::prelude::SmallRng::from_seed(Default::default());
-		for i in 0..64 {
+		for i in 0..CHUNK_ENTRIES {
 			keys[i] = rng.gen();
 			let partial_key = Entry::extract_key(keys[i], 18);
 			let e = Entry::new(Address::new(0, 0), partial_key, 18);
@@ -694,7 +752,7 @@ mod test {
 		b.iter(|| {
 			let x = f(&table, keys[index], 0, &chunk).1;
 			assert_eq!(x, index);
-			index = (index + 1) % 64;
+			index = (index + 1) % CHUNK_ENTRIES;
 		});
 	}
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -706,7 +706,7 @@ mod test {
 	}
 
 	#[test]
-	fn test_find_any_entry_same_value() {
+	fn test_find_entry_same_value() {
 		let table =
 			IndexTable { id: TableId(18), map: RwLock::new(None), path: Default::default() };
 		let mut chunk = [0u8; CHUNK_LEN];


### PR DESCRIPTION
In case there are multiple matches for the first group of 4 etries, the `sub_index` check logic would only consider the first match.