### PR TITLE
Check read bound for btree nodes.

### DIFF
--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -103,11 +103,11 @@ impl BTree {
 	}
 
 	pub fn fetch_root(root: Address, tables: TablesRef, log: &impl LogQuery) -> Result<Node> {
-		Ok(if root == NULL_ADDRESS {
-			Node::default()
+		if root == NULL_ADDRESS {
+			Ok(Node::default())
 		} else {
 			let root = BTreeTable::get_encoded_entry(root, log, tables)?;
 			Node::from_encoded(root)
-		})
+		}
 	}
 }

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -590,28 +590,28 @@ pub struct Child {
 }
 
 impl Node {
-	pub fn from_encoded(enc: Vec<u8>) -> Self {
+	pub fn from_encoded(enc: Vec<u8>) -> Result<Self> {
 		let mut entry = Entry::from_encoded(enc);
 		let mut node =
 			Node { separators: Default::default(), children: Default::default(), changed: false };
 		let mut i_children = 0;
 		let mut i_separator = 0;
 		loop {
-			if let Some(child_index) = entry.read_child_index() {
+			if let Some(child_index) = entry.read_child_index()? {
 				node.children.as_mut()[i_children].entry_index = Some(child_index);
 			}
 			i_children += 1;
 			if i_children == ORDER_CHILD {
 				break
 			}
-			if let Some(sep) = entry.read_separator() {
+			if let Some(sep) = entry.read_separator()? {
 				node.separators.as_mut()[i_separator].separator = Some(sep);
 				i_separator += 1
 			} else {
 				break
 			}
 		}
-		node
+		Ok(node)
 	}
 
 	pub fn remove_separator(&mut self, at: usize) -> Separator {
@@ -821,7 +821,7 @@ impl Node {
 	) -> Result<Option<Self>> {
 		if let Some(ix) = self.children[i].entry_index {
 			let entry = BTreeTable::get_encoded_entry(ix, log, values)?;
-			return Ok(Some(Self::from_encoded(entry)))
+			return Ok(Some(Self::from_encoded(entry)?))
 		}
 		Ok(None)
 	}

--- a/src/table.rs
+++ b/src/table.rs
@@ -186,6 +186,18 @@ impl Entry<[u8; MAX_ENTRY_BUF_SIZE]> {
 
 impl<B: AsRef<[u8]> + AsMut<[u8]>> Entry<B> {
 	#[inline(always)]
+	pub fn check_remaining_len(
+		&self,
+		len: usize,
+		error: impl Fn() -> crate::error::Error,
+	) -> Result<()> {
+		if self.0 + len > self.1.as_ref().len() {
+			return Err(error())
+		}
+		Ok(())
+	}
+
+	#[inline(always)]
 	pub fn new(data: B) -> Self {
 		Entry(0, data)
 	}


### PR DESCRIPTION
Intend to remove panic behavior on btree content reading.
fix https://github.com/paritytech/parity-db/issues/191