### PR TITLE
Representative query timing

### DIFF
--- a/admin/src/bench/mod.rs
+++ b/admin/src/bench/mod.rs
@@ -286,31 +286,23 @@ fn reader(
 		if commits == 0 {
 			continue
 		}
-		if args.archive || args.reader_check_pruned {
+		let key = if args.archive || args.reader_check_pruned {
 			let num_keys = commits * COMMIT_SIZE as u64;
-			let key = pool.key(rng.next_u64() % num_keys + seed);
-			match db.get(0, &key).unwrap() {
-				Some(_) => {
-					QUERIES_HIT.fetch_add(1, Ordering::SeqCst);
-				},
-				None => {
-					QUERIES_MISS.fetch_add(1, Ordering::SeqCst);
-				},
-			}
+			pool.key(rng.next_u64() % num_keys + seed)
 		} else {
 			let num_commit_values = (COMMIT_SIZE - COMMIT_PRUNE_SIZE) as u64;
 			let num_keys = commits * num_commit_values;
 			let mut index = rng.next_u64() % num_keys;
 			index += (index / num_commit_values + 1) * COMMIT_PRUNE_SIZE as u64;
-			let key = pool.key(index + seed);
-			match db.get(0, &key).unwrap() {
-				Some(_) => {
-					QUERIES_HIT.fetch_add(1, Ordering::SeqCst);
-				},
-				None => {
-					QUERIES_MISS.fetch_add(1, Ordering::SeqCst);
-				},
-			}
+			pool.key(index + seed)
+		};
+		match db.get(0, &key).unwrap() {
+			Some(_) => {
+				QUERIES_HIT.fetch_add(1, Ordering::SeqCst);
+			},
+			None => {
+				QUERIES_MISS.fetch_add(1, Ordering::SeqCst);
+			},
 		}
 	}
 }

--- a/admin/src/bench/mod.rs
+++ b/admin/src/bench/mod.rs
@@ -89,7 +89,8 @@ pub struct Stress {
 	#[clap(long)]
 	pub writer_sleep_time: Option<u64>,
 
-	/// By default reader threads will only test existing values. This option makes them also test pruned values.
+	/// By default reader threads will only test existing values. This option makes them also test
+	/// pruned values.
 	#[clap(long)]
 	pub reader_check_pruned: bool,
 }
@@ -126,7 +127,7 @@ impl Stress {
 			compress: self.compress,
 			ordered: self.ordered,
 			uniform: self.uniform,
-			writer_commits_per_sleep : self.writer_commits_per_sleep.unwrap_or(100),
+			writer_commits_per_sleep: self.writer_commits_per_sleep.unwrap_or(100),
 			writer_sleep_time: self.writer_sleep_time.unwrap_or(0),
 			reader_check_pruned: self.reader_check_pruned,
 		}
@@ -270,7 +271,14 @@ fn writer(
 	}
 }
 
-fn reader(db: Arc<Db>, args: Arc<Args>, pool: Arc<SizePool>, seed: u64, index: u64, shutdown: Arc<AtomicBool>) {
+fn reader(
+	db: Arc<Db>,
+	args: Arc<Args>,
+	pool: Arc<SizePool>,
+	seed: u64,
+	index: u64,
+	shutdown: Arc<AtomicBool>,
+) {
 	// Query random keys while writing
 	let mut rng = rand::rngs::SmallRng::seed_from_u64(seed + index);
 	while !shutdown.load(Ordering::Relaxed) {


### PR DESCRIPTION
Added options for controlling writer thread sleeps so that they can pause after a number of commits.
Made reader threads default to not reading pruned values. Old behaviour can be enabled with an option.
These should give a slightly more representative way of measuring query performance.