### PR TITLE
Improve DB validation tool

### DIFF
--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -95,6 +95,8 @@ pub fn run() -> Result<(), String> {
 				check.range_end,
 				check.display,
 				check.display_value_max,
+				check.fast,
+				true,
 			);
 			db.dump(check_param).map_err(|e| format!("Check error: {e:?}"))?;
 		},
@@ -287,4 +289,9 @@ pub struct Check {
 	/// Max length for value to display (when using --display).
 	#[clap(long)]
 	pub display_value_max: Option<u64>,
+
+	/// Sort index to optimize disk access. Requires the largest DB index to be able to fit in
+	/// memory.
+	#[clap(long)]
+	pub fast: bool,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1462,6 +1462,10 @@ pub mod check {
 		pub bound: Option<u64>,
 		/// Verbosity.
 		pub display: CheckDisplay,
+		/// Ordered validation.
+		pub fast: bool,
+		/// Make sure free lists are correct.
+		pub validate_free_refs: bool,
 	}
 
 	impl CheckOptions {
@@ -1472,6 +1476,8 @@ pub mod check {
 			bound: Option<u64>,
 			display_content: bool,
 			truncate_value_display: Option<u64>,
+			fast: bool,
+			validate_free_refs: bool,
 		) -> Self {
 			let display = if display_content {
 				match truncate_value_display {
@@ -1481,7 +1487,7 @@ pub mod check {
 			} else {
 				CheckDisplay::None
 			};
-			CheckOptions { column, from, bound, display }
+			CheckOptions { column, from, bound, display, fast, validate_free_refs }
 		}
 	}
 }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -78,7 +78,7 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 		log::info!("Migrating col {}", c);
 		source.iter_column_index_while(
 			c,
-			|IterState { chunk_index: index, key, rc, mut value }| {
+			|IterState { item_index: index, key, rc, mut value, .. }| {
 				//TODO: more efficient ref migration
 				for _ in 0..rc {
 					let value = std::mem::take(&mut value);


### PR DESCRIPTION
* Added an alternative hash column iteration. The index is copied to memory, sorted by disk offset and then iterated. This makes checking large databases 100x faster.
* Also added some code to follow free entry lists and check them for correctness.