### PR TITLE
Skip obsolete logs when recovering

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,7 @@ jobs:
           command: test
           args: --test loom --features=loom,instrumentation --release --verbose
         env:
-          LOOM_MAX_PREEMPTIONS: 3
+          LOOM_MAX_PREEMPTIONS: 2
           LOOM_MAX_BRANCHES: 2000
 
   test_aarch64:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ memmap2 = "0.5"
 parking_lot = "0.12.0"
 rand = "0.8.4"
 snap = "1"
-loom = { version = "0.5.1", optional = true }
+loom = { version = "0.5.6", optional = true }
 siphasher = "0.3.10"
 
 [dev-dependencies]

--- a/src/btree/mod.rs
+++ b/src/btree/mod.rs
@@ -257,6 +257,20 @@ impl BTreeTable {
 		Ok(())
 	}
 
+	pub fn skip_plan(&self, action: LogAction, log: &mut LogReader) -> Result<()> {
+		let tables = self.tables.upgradable_read();
+		match action {
+			LogAction::InsertValue(record) => {
+				tables[record.table.size_tier() as usize].skip_plan(record.index, log)?;
+			},
+			_ => {
+				log::error!(target: "parity-db", "Unexpected log action");
+				return Err(Error::Corruption("Unexpected log action".to_string()))
+			},
+		}
+		Ok(())
+	}
+
 	pub fn complete_plan(&self, log: &mut LogWriter) -> Result<()> {
 		let tables = self.tables.read();
 		for t in tables.iter() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -187,7 +187,7 @@ impl DbInner {
 		}
 
 		let mut record_file_path: std::path::PathBuf = options.path.clone();
-		record_file_path.push("record");
+		record_file_path.push("log_record");
 		let record_file = try_io!(std::fs::OpenOptions::new()
 			.create(true)
 			.read(true)

--- a/src/log.rs
+++ b/src/log.rs
@@ -706,9 +706,9 @@ impl Log {
 			queue.drain(0..count).collect()
 		};
 		for (id, ref mut file) in cleaned.iter_mut() {
-			log::debug!(target: "parity-db", "Cleaned: {}", id);
 			try_io!(file.rewind());
 			try_io!(file.set_len(0));
+			log::debug!(target: "parity-db", "Cleaned log {}", id);
 		}
 		// Move cleaned logs back to the pool
 		let mut pool = self.log_pool.write();

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -28,7 +28,7 @@ fn exec_simple_commit_and_write_concurrency(is_btree: bool, is_ref_counted: bool
 
 		let db = global_db.clone();
 		let t1 = thread::spawn(move || {
-			db.commit::<_, Vec<u8>>((1..=20).map(|i| (0, vec![2 * i], Some(vec![2 * i]))))
+			db.commit::<_, Vec<u8>>((1..=10).map(|i| (0, vec![2 * i], Some(vec![2 * i]))))
 				.unwrap();
 			db.process_commits().unwrap();
 			db.clean_logs().unwrap();
@@ -36,7 +36,7 @@ fn exec_simple_commit_and_write_concurrency(is_btree: bool, is_ref_counted: bool
 
 		let db = global_db.clone();
 		let t2 = thread::spawn(move || {
-			db.commit::<_, Vec<u8>>((1..=20).map(|i| (0, vec![2 * i + 1], Some(vec![2 * i + 1]))))
+			db.commit::<_, Vec<u8>>((1..=10).map(|i| (0, vec![2 * i + 1], Some(vec![2 * i + 1]))))
 				.unwrap();
 			db.flush_logs().unwrap();
 			db.process_reindex().unwrap();
@@ -44,7 +44,7 @@ fn exec_simple_commit_and_write_concurrency(is_btree: bool, is_ref_counted: bool
 
 		let db = global_db.clone();
 		let t3 = thread::spawn(move || {
-			db.commit::<_, Vec<u8>>((1..=20).map(|i| (0, vec![2 * i], None))).unwrap();
+			db.commit::<_, Vec<u8>>((1..=10).map(|i| (0, vec![2 * i], None))).unwrap();
 			db.enact_logs().unwrap();
 		});
 


### PR DESCRIPTION
When recoveing logs, the database was operating under assumption that re-applying older commits is generally fine. In reality there are consistency issues when a  older commit is re-applied without also replaying the whole sequence that leads to the latest commit. Here I've added a file that keeps the last record id. This file gets fsynced after syncing all the data files. Which should guarantee that all previous records are solid. When recovring logs there's now a check for such obsolete records and all such records are skipped.