### PR TITLE
Limit log cleanup queue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,7 @@ jobs:
           args: --test loom --features=loom,instrumentation --release --verbose
         env:
           LOOM_MAX_PREEMPTIONS: 2
-          LOOM_MAX_BRANCHES: 2000
+          LOOM_MAX_BRANCHES: 3000
 
   test_aarch64:
     runs-on: ubuntu-latest

--- a/src/db.rs
+++ b/src/db.rs
@@ -726,7 +726,7 @@ impl DbInner {
 
 				let max_logs = if self.options.sync_data { MAX_LOG_FILES } else { KEEP_LOGS };
 				let dirty_logs = self.log.num_dirty_logs();
-				if dirty_logs > max_logs {
+				while self.log.num_dirty_logs() > max_logs {
 					log::debug!(target: "parity-db", "Waiting for log cleanup. Queued: {}", dirty_logs);
 					self.cleanup_queue_wait.wait();
 				}

--- a/src/db.rs
+++ b/src/db.rs
@@ -726,9 +726,11 @@ impl DbInner {
 
 				let max_logs = if self.options.sync_data { MAX_LOG_FILES } else { KEEP_LOGS };
 				let dirty_logs = self.log.num_dirty_logs();
-				while self.log.num_dirty_logs() > max_logs {
-					log::debug!(target: "parity-db", "Waiting for log cleanup. Queued: {}", dirty_logs);
-					self.cleanup_queue_wait.wait();
+				if !validation_mode {
+					while self.log.num_dirty_logs() > max_logs {
+						log::debug!(target: "parity-db", "Waiting for log cleanup. Queued: {}", dirty_logs);
+						self.cleanup_queue_wait.wait();
+					}
 				}
 			}
 			Ok(true)

--- a/src/db.rs
+++ b/src/db.rs
@@ -602,8 +602,6 @@ impl DbInner {
 							Ok(next) => next,
 							Err(e) => {
 								log::debug!(target: "parity-db", "Error reading log: {:?}", e);
-								drop(reader);
-								self.log.clear_replay_logs();
 								return Ok(false)
 							},
 						};
@@ -626,7 +624,7 @@ impl DbInner {
 										)
 									},
 								) {
-									log::warn!(target: "parity-db", "Error replaying log: {:?}. Reverting", e);
+									log::warn!(target: "parity-db", "Error validating log: {:?}.", e);
 									drop(reader);
 									self.log.clear_replay_logs();
 									return Ok(false)
@@ -643,7 +641,7 @@ impl DbInner {
 										)
 									},
 								) {
-									log::warn!(target: "parity-db", "Error replaying log: {:?}. Reverting", e);
+									log::warn!(target: "parity-db", "Error validating log: {:?}.", e);
 									drop(reader);
 									self.log.clear_replay_logs();
 									return Ok(false)

--- a/src/db.rs
+++ b/src/db.rs
@@ -51,8 +51,8 @@ const MAX_COMMIT_QUEUE_BYTES: usize = 16 * 1024 * 1024;
 const MAX_LOG_QUEUE_BYTES: i64 = 128 * 1024 * 1024;
 // Minimum size of log file before it is considered full.
 const MIN_LOG_SIZE_BYTES: u64 = 64 * 1024 * 1024;
-// Number of log files to keep after flush when sync mode is disabled. Give the database some chance to
-// recover in case of crash.
+// Number of log files to keep after flush when sync mode is disabled. Give the database some chance
+// to recover in case of crash.
 const KEEP_LOGS: usize = 16;
 // Hard limit on the number of log files in sync mode. The number of log may grow while existing
 // logs are waiting on fsync. Commits will be throttled if total number of log files exceeds this


### PR DESCRIPTION
On machines with slow fsync it is possible that the log cleanup queue grows to gigabytes while fsync is in progress. This PR add a limit to the cleanup queue, pausing commits if it grows too much,

Also tweaked error handling for the log recovory. If recovery fails for reasons other than the bad log file we keep the log files around, instead of deleting them and hoping fo the best. If replay is successfull, the logs are deleted right away (after fsync), instead of waiting for the database to be closed.