### PR TITLE
Fix find_entry for zero partial key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
In rare cases when target partial key is all zeroes and the index chunk contains precceding empty entries, these empty entries are returned instead. 