### PR TITLE
Call madvise for existing index files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Currently `madvise` call for the random IO hint is only performed on the new index creation. It should be done on opening an existing index as well. 