### PR TITLE
Record id for cleaning log overlay.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -355,7 +355,7 @@ impl DbInner {
 		let mut overlay = self.commit_overlay.write();
 
 		queue.record_id += 1;
-		let record_id = queue.record_id + 1;
+		let record_id = queue.record_id;
 
 		let mut bytes = 0;
 		for (c, indexed) in &commit.indexed {


### PR DESCRIPTION
While debugging another branch, this counter looks odd to me.
I feel like it should be like in this commit.
But maybe this was a trick to avoid some concurrency issue (iiuc this makes cleaning the log overlay always late by one record id).
cc @arkpar @MattHalpinParity 