### PR TITLE
Use mmap IO for value tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -114,12 +114,12 @@ pub fn run() -> Result<(), String> {
 
 			let mut db_options = options.clone();
 			if args.compress {
-				for mut c in &mut db_options.columns {
+				for c in &mut db_options.columns {
 					c.compression = parity_db::CompressionType::Lz4;
 				}
 			}
 			if args.uniform {
-				for mut c in &mut db_options.columns {
+				for c in &mut db_options.columns {
 					c.uniform = true;
 				}
 			}

--- a/src/column.rs
+++ b/src/column.rs
@@ -27,7 +27,7 @@ use std::{
 	},
 };
 
-const MIN_INDEX_BITS: u8 = 16;
+pub const MIN_INDEX_BITS: u8 = 16;
 // Measured in index entries
 const MAX_REINDEX_BATCH: usize = 8192;
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -10,7 +10,12 @@ use crate::{
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 
-const RESERVE_ADDRESS_SPACE: usize = 512 * 1024 * 1024;
+#[cfg(not(test))]
+const RESERVE_ADDRESS_SPACE: usize = 1024 * 1024 * 1024; // 1 Gb
+
+// Use different value for tests to work around docker limits on the test machine.
+#[cfg(test)]
+const RESERVE_ADDRESS_SPACE: usize = 64 * 1024 * 1024; // 64 Mb
 
 #[cfg(target_os = "linux")]
 fn disable_read_ahead(file: &std::fs::File) -> std::io::Result<()> {

--- a/src/file.rs
+++ b/src/file.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 
-const RESERVE_ADDRESS_SPACE: usize = 1024 * 1024 * 1024;
+const RESERVE_ADDRESS_SPACE: usize = 64 * 1024 * 1024;
 
 #[cfg(target_os = "linux")]
 fn disable_read_ahead(file: &std::fs::File) -> std::io::Result<()> {

--- a/src/file.rs
+++ b/src/file.rs
@@ -147,7 +147,8 @@ impl TableFile {
 				madvise_random(&mut map);
 				*map_and_file = Some((map, file));
 			},
-			Some((_map, file)) => {
+			Some((map, file)) => {
+				std::mem::drop(map);
 				try_io!(file.set_len(capacity * entry_size as u64));
 				let mut m = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
 				madvise_random(&mut m);

--- a/src/file.rs
+++ b/src/file.rs
@@ -39,11 +39,7 @@ fn disable_read_ahead(_file: &std::fs::File) -> std::io::Result<()> {
 #[cfg(unix)]
 pub fn madvise_random(map: &mut memmap2::MmapMut) {
 	unsafe {
-		libc::madvise(
-			map.as_mut_ptr() as _,
-			map.len(),
-			libc::MADV_RANDOM,
-		);
+		libc::madvise(map.as_mut_ptr() as _, map.len(), libc::MADV_RANDOM);
 	}
 }
 
@@ -150,13 +146,13 @@ impl TableFile {
 				let mut map = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
 				madvise_random(&mut map);
 				*map_and_file = Some((map, file));
-			}
+			},
 			Some((map, file)) => {
 				try_io!(file.set_len(capacity * entry_size as u64));
-				let mut m  = try_io!(unsafe { memmap2::MmapMut::map_mut(&*file) });
+				let mut m = try_io!(unsafe { memmap2::MmapMut::map_mut(&*file) });
 				madvise_random(&mut m);
 				*map = m;
-			}
+			},
 		}
 		Ok(())
 	}

--- a/src/file.rs
+++ b/src/file.rs
@@ -4,8 +4,8 @@
 //! Utilities for db file.
 
 use crate::{
-	error::{try_io, Error, Result},
-	parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard},
+	error::{try_io, Result},
+	parking_lot::RwLock,
 	table::TableId,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -36,33 +36,25 @@ fn disable_read_ahead(_file: &std::fs::File) -> std::io::Result<()> {
 	Ok(())
 }
 
-// `File::sync_data` uses F_FULLSYNC fcntl on MacOS. It it supposed to be
-// the safest way to make sure data is fully persisted. However starting from
-// MacOS 11.0 it severely degrades parallel write performance, even when writing to
-// other files. Regular `fsync` is good enough for our use case.
-// SSDs used in modern macs seem to be able to flush data even on unexpected power loss.
-// We performed some testing with power shutdowns and kernel panics on both mac hardware
-// and VMs and in all cases `fsync` was enough to prevent data corruption.
-#[cfg(target_os = "macos")]
-fn fsync(file: &std::fs::File) -> std::io::Result<()> {
-	use std::os::unix::io::AsRawFd;
-	if unsafe { libc::fsync(file.as_raw_fd()) } != 0 {
-		Err(std::io::Error::last_os_error())
-	} else {
-		Ok(())
+#[cfg(unix)]
+fn madvise_random(map: &mut memmap2::MmapMut) {
+	unsafe {
+		libc::madvise(
+			map.as_mut_ptr() as _,
+			map.len(),
+			libc::MADV_RANDOM,
+		);
 	}
 }
 
-#[cfg(not(target_os = "macos"))]
-fn fsync(file: &std::fs::File) -> std::io::Result<()> {
-	file.sync_data()
-}
+#[cfg(not(unix))]
+fn madvise_random(_id: TableId, _map: &mut memmap2::MmapMut) {}
 
 const GROW_SIZE_BYTES: u64 = 256 * 1024;
 
 #[derive(Debug)]
 pub struct TableFile {
-	pub file: RwLock<Option<std::fs::File>>,
+	pub map: RwLock<Option<(memmap2::MmapMut, std::fs::File)>>,
 	pub path: std::path::PathBuf,
 	pub capacity: AtomicU64,
 	pub id: TableId,
@@ -71,7 +63,7 @@ pub struct TableFile {
 impl TableFile {
 	pub fn open(filepath: std::path::PathBuf, entry_size: u16, id: TableId) -> Result<Self> {
 		let mut capacity = 0u64;
-		let file = if std::fs::metadata(&filepath).is_ok() {
+		let map = if std::fs::metadata(&filepath).is_ok() {
 			let file = try_io!(std::fs::OpenOptions::new()
 				.read(true)
 				.write(true)
@@ -85,13 +77,15 @@ impl TableFile {
 			} else {
 				capacity = len / entry_size as u64;
 			}
-			Some(file)
+			let mut map = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
+			madvise_random(&mut map);
+			Some((map, file))
 		} else {
 			None
 		};
 		Ok(TableFile {
 			path: filepath,
-			file: RwLock::new(file),
+			map: RwLock::new(map),
 			capacity: AtomicU64::new(capacity),
 			id,
 		})
@@ -110,53 +104,37 @@ impl TableFile {
 
 	#[cfg(unix)]
 	pub fn read_at(&self, buf: &mut [u8], offset: u64) -> Result<()> {
-		use std::os::unix::fs::FileExt;
-		try_io!(self
-			.file
-			.read()
-			.as_ref()
-			.ok_or_else(|| Error::Corruption("File does not exist.".into()))?
-			.read_exact_at(buf, offset));
+		let offset = offset as usize;
+		let map = self.map.read();
+		let (map, _) = map.as_ref().unwrap();
+		buf.copy_from_slice(&map[offset..offset + buf.len()]);
 		Ok(())
 	}
 
 	#[cfg(unix)]
 	pub fn write_at(&self, buf: &[u8], offset: u64) -> Result<()> {
-		use std::os::unix::fs::FileExt;
-		try_io!(self.file.read().as_ref().unwrap().write_all_at(buf, offset));
+		let map = self.map.read();
+		let (map, _) = map.as_ref().unwrap();
+		let offset = offset as usize;
+
+		// Nasty mutable pointer cast. We do ensure that all chunks that are being written are
+		// accessed through the overlay in other threads.
+		let ptr: *mut u8 = map.as_ptr() as *mut u8;
+		let data: &mut [u8] = unsafe {
+			let ptr = ptr.add(offset);
+			std::slice::from_raw_parts_mut(ptr, buf.len())
+		};
+		data.copy_from_slice(buf);
 		Ok(())
 	}
 
 	#[cfg(windows)]
 	pub fn read_at(&self, mut buf: &mut [u8], mut offset: u64) -> Result<()> {
-		use crate::error::Error;
-		use std::{io, os::windows::fs::FileExt};
-
-		let file = self.file.read();
-		let file = file.as_ref().ok_or_else(|| Error::Corruption("File does not exist.".into()))?;
-
-		while !buf.is_empty() {
-			match file.seek_read(buf, offset) {
-				Ok(0) => break,
-				Ok(n) => {
-					buf = &mut buf[n..];
-					offset += n as u64;
-				},
-				Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {
-					// Try again
-				},
-				Err(e) => return Err(Error::Io(e)),
-			}
-		}
-
-		if !buf.is_empty() {
-			Err(Error::Io(io::Error::new(
-				io::ErrorKind::UnexpectedEof,
-				"failed to fill whole buffer",
-			)))
-		} else {
-			Ok(())
-		}
+		let (map, _) = self.map.read().as_ref().unwrap();
+		let map = map.as_mut().unwrap();
+		let offset = offset as usize;
+		map[offset..offset + buf.len()].copy_from_slice(buf);
+		Ok(())
 	}
 
 	#[cfg(windows)]
@@ -193,26 +171,36 @@ impl TableFile {
 		capacity += GROW_SIZE_BYTES / entry_size as u64;
 
 		self.capacity.store(capacity, Ordering::Relaxed);
-		let mut file = self.file.upgradable_read();
-		if file.is_none() {
-			let mut wfile = RwLockUpgradableReadGuard::upgrade(file);
-			*wfile = Some(self.create_file()?);
-			file = RwLockWriteGuard::downgrade_to_upgradable(wfile);
+		let mut map_and_file = self.map.write();
+		match map_and_file.as_mut() {
+			None => {
+				let file = self.create_file()?;
+				try_io!(file.set_len(capacity * entry_size as u64));
+				let mut map = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
+				madvise_random(&mut map);
+				*map_and_file = Some((map, file));
+			}
+			Some((map, file)) => {
+				try_io!(file.set_len(capacity * entry_size as u64));
+				let mut m  = try_io!(unsafe { memmap2::MmapMut::map_mut(&*file) });
+				madvise_random(&mut m);
+				*map = m;
+			}
 		}
-		try_io!(file.as_ref().unwrap().set_len(capacity * entry_size as u64));
 		Ok(())
 	}
 
 	pub fn flush(&self) -> Result<()> {
-		if let Some(file) = self.file.read().as_ref() {
-			try_io!(fsync(file));
+		if let Some((map, _)) = self.map.read().as_ref() {
+			try_io!(map.flush());
 		}
 		Ok(())
 	}
 
 	pub fn remove(&self) -> Result<()> {
-		let mut file = self.file.write();
-		if let Some(file) = file.take() {
+		let mut map = self.map.write();
+		if let Some((map, file)) = map.take() {
+			drop(map);
 			drop(file);
 			try_io!(std::fs::remove_file(&self.path));
 		}

--- a/src/file.rs
+++ b/src/file.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 
-const RESERVE_ADDRESS_SPACE: usize = 64 * 1024 * 1024;
+const RESERVE_ADDRESS_SPACE: usize = 512 * 1024 * 1024;
 
 #[cfg(target_os = "linux")]
 fn disable_read_ahead(file: &std::fs::File) -> std::io::Result<()> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,14 +2,14 @@
 // This file is dual-licensed as Apache-2.0 or MIT.
 
 use crate::{
-	column::ColId,
+	column::{ColId, MIN_INDEX_BITS},
 	display::hex,
 	error::{try_io, Error, Result},
+	file::madvise_random,
 	log::{LogQuery, LogReader, LogWriter},
 	parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard},
 	stats::{self, ColumnStats},
 	table::{key::TableKey, SIZE_TIERS_BITS},
-	file::madvise_random,
 	Key,
 };
 #[cfg(target_arch = "x86")]
@@ -181,6 +181,14 @@ impl TableId {
 
 	pub fn total_entries(&self) -> u64 {
 		total_entries(self.index_bits())
+	}
+
+	pub fn log_index(&self) -> usize {
+		self.col() as usize * (64 - MIN_INDEX_BITS) as usize + self.index_bits() as usize
+	}
+
+	pub const fn max_log_indicies(num_columns: usize) -> usize {
+		(64 - MIN_INDEX_BITS) as usize * num_columns
 	}
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -187,6 +187,12 @@ impl TableId {
 		self.col() as usize * (64 - MIN_INDEX_BITS) as usize + self.index_bits() as usize
 	}
 
+	pub fn from_log_index(i: usize) -> Self {
+		let col = i / (64 - MIN_INDEX_BITS) as usize;
+		let bits = i % (64 - MIN_INDEX_BITS) as usize;
+		TableId::new(col as ColId, bits as u8)
+	}
+
 	pub const fn max_log_indicies(num_columns: usize) -> usize {
 		(64 - MIN_INDEX_BITS) as usize * num_columns
 	}

--- a/src/log.rs
+++ b/src/log.rs
@@ -93,6 +93,7 @@ impl LogOverlays {
 }
 
 
+// Loom is missing support for guard projection, so we copy the data as a workaround.
 #[cfg(feature = "loom")]
 pub struct  MappedBytesGuard<'a> {
 	_phantom: std::marker::PhantomData<&'a ()>,

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,8 +1,6 @@
 // Copyright 2021-2022 Parity Technologies (UK) Ltd.
 // This file is dual-licensed as Apache-2.0 or MIT.
 
-use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
-
 use crate::{
 	column::ColId,
 	error::{try_io, Error, Result},
@@ -18,6 +16,7 @@ use std::{
 	io::{ErrorKind, Read, Seek, Write},
 	sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
 };
+use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 
 const MAX_LOG_POOL_SIZE: usize = 16;
 const BEGIN_RECORD: u8 = 1;

--- a/src/log.rs
+++ b/src/log.rs
@@ -9,6 +9,7 @@ use crate::{
 	parking_lot::{RwLock, RwLockWriteGuard},
 	table::TableId as ValueTableId,
 };
+use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 use std::{
 	cmp::min,
 	collections::{HashMap, VecDeque},
@@ -16,7 +17,6 @@ use std::{
 	io::{ErrorKind, Read, Seek, Write},
 	sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
 };
-use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 
 const MAX_LOG_POOL_SIZE: usize = 16;
 const BEGIN_RECORD: u8 = 1;

--- a/src/log.rs
+++ b/src/log.rs
@@ -92,26 +92,22 @@ impl LogOverlays {
 	}
 }
 
-
 // Loom is missing support for guard projection, so we copy the data as a workaround.
 #[cfg(feature = "loom")]
-pub struct  MappedBytesGuard<'a> {
+pub struct MappedBytesGuard<'a> {
 	_phantom: std::marker::PhantomData<&'a ()>,
 	data: Vec<u8>,
 }
 
 #[cfg(feature = "loom")]
-impl <'a> MappedBytesGuard<'a> {
+impl<'a> MappedBytesGuard<'a> {
 	fn new(data: Vec<u8>) -> Self {
-		Self {
-			_phantom: std::marker::PhantomData,
-			data,
-		}
+		Self { _phantom: std::marker::PhantomData, data }
 	}
 }
 
 #[cfg(feature = "loom")]
-impl <'a> std::ops::Deref for MappedBytesGuard<'a> {
+impl<'a> std::ops::Deref for MappedBytesGuard<'a> {
 	type Target = [u8];
 
 	fn deref(&self) -> &Self::Target {
@@ -140,7 +136,8 @@ impl LogQuery for RwLock<LogOverlays> {
 
 	#[cfg(not(feature = "loom"))]
 	fn value_ref<'a>(&'a self, table: ValueTableId, index: u64) -> Option<Self::ValueRef<'a>> {
-		let lock = parking_lot::RwLockReadGuard::try_map(self.read(), |o| o.value_ref(table, index));
+		let lock =
+			parking_lot::RwLockReadGuard::try_map(self.read(), |o| o.value_ref(table, index));
 		lock.ok()
 	}
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -124,6 +124,12 @@ impl TableId {
 	pub const fn max_log_tables(num_columns: usize) -> usize {
 		SIZE_TIERS * num_columns
 	}
+
+	pub fn from_log_index(i: usize) -> Self {
+		let col = i / SIZE_TIERS;
+		let tier = i % SIZE_TIERS;
+		Self::new(col as ColId, tier as u8)
+	}
 }
 
 impl std::fmt::Display for TableId {


### PR DESCRIPTION
This works much faster when performance is limited by OS page cache. When the database is relatively small and fits entirely in the page cache, making kernel calls becomes too expensive.
Also removed extra copy to a temp buffer when reading values from file. 
Also optimized overlay layout a bit. The top level is a vec now instead of a hashmap.