### PR TITLE
Remove log overlay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-db"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -84,11 +84,7 @@ impl BTree {
 		root.is_balanced(tables, 0)
 	}
 
-	pub fn get(
-		&self,
-		key: &[u8],
-		values: TablesRef,
-	) -> Result<Option<Vec<u8>>> {
+	pub fn get(&self, key: &[u8], values: TablesRef) -> Result<Option<Vec<u8>>> {
 		let root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), values)?;
 		if let Some(address) = root.get(key, values)? {
 			let key_query = TableKeyQuery::Fetch(None);

--- a/src/btree/btree.rs
+++ b/src/btree/btree.rs
@@ -9,7 +9,6 @@ use crate::{
 	column::Column,
 	db::{RcKey, RcValue},
 	error::Result,
-	log::{LogQuery, LogWriter},
 	table::key::TableKeyQuery,
 	Operation,
 };
@@ -26,8 +25,8 @@ impl BTree {
 		BTree { root_index, depth, record_id }
 	}
 
-	pub fn open(values: TablesRef, log: &impl LogQuery, record_id: u64) -> Result<Self> {
-		let btree_header = BTreeTable::btree_header(log, values)?;
+	pub fn open(values: TablesRef, record_id: u64) -> Result<Self> {
+		let btree_header = BTreeTable::btree_header(values)?;
 
 		let root_index =
 			if btree_header.root == NULL_ADDRESS { None } else { Some(btree_header.root) };
@@ -38,29 +37,28 @@ impl BTree {
 		&mut self,
 		mut changes: &[Operation<RcKey, RcValue>],
 		btree: TablesRef,
-		log: &mut LogWriter,
 	) -> Result<()> {
-		let mut root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), btree, log)?;
+		let mut root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), btree)?;
 		let changes = &mut changes;
 
 		while !changes.is_empty() {
-			match root.change(None, self.depth, changes, btree, log)? {
+			match root.change(None, self.depth, changes, btree)? {
 				(Some((sep, right)), _) => {
 					// add one level
 					self.depth += 1;
 					let left = std::mem::take(&mut root);
 					let left_index = self.root_index.take();
-					let new_index = BTreeTable::write_node_plan(btree, left, log, left_index)?;
+					let new_index = BTreeTable::write_node(btree, left, left_index)?;
 					let new_index = if new_index.is_some() { new_index } else { left_index };
 					root.set_child(0, Node::new_child(new_index));
 					root.set_child(1, right);
 					root.set_separator(0, sep);
 				},
 				(_, true) =>
-					if let Some((node_index, node)) = root.need_remove_root(btree, log)? {
+					if let Some((node_index, node)) = root.need_remove_root(btree)? {
 						self.depth -= 1;
 						if let Some(index) = self.root_index.take() {
-							BTreeTable::write_plan_remove_node(btree, log, index)?;
+							BTreeTable::write_remove_node(btree, index)?;
 						}
 						self.root_index = node_index;
 						root = node;
@@ -71,7 +69,7 @@ impl BTree {
 		}
 
 		if root.changed {
-			let new_index = BTreeTable::write_node_plan(btree, root, log, self.root_index)?;
+			let new_index = BTreeTable::write_node(btree, root, self.root_index)?;
 
 			if new_index.is_some() {
 				self.root_index = new_index;
@@ -81,32 +79,31 @@ impl BTree {
 	}
 
 	#[cfg(test)]
-	pub fn is_balanced(&self, tables: TablesRef, log: &impl LogQuery) -> Result<bool> {
-		let root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), tables, log)?;
-		root.is_balanced(tables, log, 0)
+	pub fn is_balanced(&self, tables: TablesRef) -> Result<bool> {
+		let root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), tables)?;
+		root.is_balanced(tables, 0)
 	}
 
 	pub fn get(
 		&self,
 		key: &[u8],
 		values: TablesRef,
-		log: &impl LogQuery,
 	) -> Result<Option<Vec<u8>>> {
-		let root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), values, log)?;
-		if let Some(address) = root.get(key, values, log)? {
+		let root = BTree::fetch_root(self.root_index.unwrap_or(NULL_ADDRESS), values)?;
+		if let Some(address) = root.get(key, values)? {
 			let key_query = TableKeyQuery::Fetch(None);
-			let r = Column::get_value(key_query, address, values, log)?;
+			let r = Column::get_value(key_query, address, values)?;
 			Ok(r.map(|r| r.1))
 		} else {
 			Ok(None)
 		}
 	}
 
-	pub fn fetch_root(root: Address, tables: TablesRef, log: &impl LogQuery) -> Result<Node> {
+	pub fn fetch_root(root: Address, tables: TablesRef) -> Result<Node> {
 		if root == NULL_ADDRESS {
 			Ok(Node::default())
 		} else {
-			let root = BTreeTable::get_encoded_entry(root, log, tables)?;
+			let root = BTreeTable::get_encoded_entry(root, tables)?;
 			Node::from_encoded(root)
 		}
 	}

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -85,7 +85,8 @@ impl<'a> BTreeIterator<'a> {
 
 	pub fn seek(&mut self, key: &[u8]) -> Result<()> {
 		// seek require log do not change
-		let record_id = self.commit_overlay.read().last_btree_commit();
+		let commit_overlay = self.commit_overlay.read();
+		let record_id = commit_overlay.last_btree_commit();
 		self.last_key = LastKey::Seeked(key.to_vec());
 		self.pending_backend = None;
 		self.seek_backend(SeekTo::Include(key), record_id, self.table)
@@ -96,7 +97,8 @@ impl<'a> BTreeIterator<'a> {
 	}
 
 	pub fn seek_to_last(&mut self) -> Result<()> {
-		let record_id = self.commit_overlay.read().last_btree_commit();
+		let commit_overlay = self.commit_overlay.read();
+		let record_id = commit_overlay.last_btree_commit();
 		self.last_key = LastKey::End;
 		self.seek_backend_to_last(record_id, self.table)
 	}
@@ -120,7 +122,7 @@ impl<'a> BTreeIterator<'a> {
 			};
 			let record_id = commit_overlay.last_btree_commit();
 			// No consistency over iteration, allows dropping lock to overlay.
-			drop(commit_overlay);
+			//drop(commit_overlay);
 			if record_id != self.iter.1.record_id {
 				self.pending_backend = None;
 			}

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -220,12 +220,7 @@ impl<'a> BTreeIterator<'a> {
 		iter.next(tree, col, direction)
 	}
 
-	fn seek_backend(
-		&mut self,
-		seek_to: SeekTo,
-		record_id: u64,
-		col: &BTreeTable,
-	) -> Result<()> {
+	fn seek_backend(&mut self, seek_to: SeekTo, record_id: u64, col: &BTreeTable) -> Result<()> {
 		let BtreeIterBackend(tree, iter) = &mut self.iter;
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, record_id))?;
@@ -235,11 +230,7 @@ impl<'a> BTreeIterator<'a> {
 		iter.seek(seek_to, tree, col)
 	}
 
-	fn seek_backend_to_last(
-		&mut self,
-		record_id: u64,
-		col: &BTreeTable,
-	) -> Result<()> {
+	fn seek_backend_to_last(&mut self, record_id: u64, col: &BTreeTable) -> Result<()> {
 		let BtreeIterBackend(tree, iter) = &mut self.iter;
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, record_id))?;
@@ -375,12 +366,7 @@ impl BTreeIterState {
 		Ok(None)
 	}
 
-	pub fn seek(
-		&mut self,
-		seek_to: SeekTo,
-		btree: &mut BTree,
-		col: &BTreeTable,
-	) -> Result<()> {
+	pub fn seek(&mut self, seek_to: SeekTo, btree: &mut BTree, col: &BTreeTable) -> Result<()> {
 		self.state.clear();
 		col.with_locked(|b| {
 			let root = BTree::fetch_root(btree.root_index.unwrap_or(NULL_ADDRESS), b)?;
@@ -388,11 +374,7 @@ impl BTreeIterState {
 		})
 	}
 
-	pub fn seek_to_last(
-		&mut self,
-		btree: &mut BTree,
-		col: &BTreeTable,
-	) -> Result<()> {
+	pub fn seek_to_last(&mut self, btree: &mut BTree, col: &BTreeTable) -> Result<()> {
 		self.seek(SeekTo::Last, btree, col)
 	}
 }

--- a/src/btree/iter.rs
+++ b/src/btree/iter.rs
@@ -229,12 +229,7 @@ impl<'a> BTreeIterator<'a> {
 		iter.next(tree, col, direction)
 	}
 
-	fn seek_backend(
-		&mut self,
-		seek_to: SeekTo,
-		record_id: u64,
-		col: &BTreeTable,
-	) -> Result<()> {
+	fn seek_backend(&mut self, seek_to: SeekTo, record_id: u64, col: &BTreeTable) -> Result<()> {
 		let BtreeIterBackend(tree, iter) = &mut self.iter;
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, record_id))?;
@@ -244,11 +239,7 @@ impl<'a> BTreeIterator<'a> {
 		iter.seek(seek_to, tree, col)
 	}
 
-	fn seek_backend_to_last(
-		&mut self,
-		record_id: u64,
-		col: &BTreeTable,
-	) -> Result<()> {
+	fn seek_backend_to_last(&mut self, record_id: u64, col: &BTreeTable) -> Result<()> {
 		let BtreeIterBackend(tree, iter) = &mut self.iter;
 		if record_id != tree.record_id {
 			let new_tree = col.with_locked(|btree| BTree::open(btree, record_id))?;
@@ -384,12 +375,7 @@ impl BTreeIterState {
 		Ok(None)
 	}
 
-	pub fn seek(
-		&mut self,
-		seek_to: SeekTo,
-		btree: &mut BTree,
-		col: &BTreeTable,
-	) -> Result<()> {
+	pub fn seek(&mut self, seek_to: SeekTo, btree: &mut BTree, col: &BTreeTable) -> Result<()> {
 		self.state.clear();
 		col.with_locked(|b| {
 			let root = BTree::fetch_root(btree.root_index.unwrap_or(NULL_ADDRESS), b)?;
@@ -397,11 +383,7 @@ impl BTreeIterState {
 		})
 	}
 
-	pub fn seek_to_last(
-		&mut self,
-		btree: &mut BTree,
-		col: &BTreeTable,
-	) -> Result<()> {
+	pub fn seek_to_last(&mut self, btree: &mut BTree, col: &BTreeTable) -> Result<()> {
 		self.seek(SeekTo::Last, btree, col)
 	}
 }

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -22,12 +22,7 @@ impl Node {
 		self.separators.iter().rposition(|separator| separator.separator.is_some())
 	}
 
-	pub fn write_child(
-		&mut self,
-		i: usize,
-		child: Self,
-		btree: TablesRef,
-	) -> Result<()> {
+	pub fn write_child(&mut self, i: usize, child: Self, btree: TablesRef) -> Result<()> {
 		if child.changed {
 			let child_index = self.children[i].entry_index;
 			let new_index = BTreeTable::write_node(btree, child, child_index)?;
@@ -295,12 +290,7 @@ impl Node {
 		Ok((None, self.need_rebalance()))
 	}
 
-	pub fn rebalance(
-		&mut self,
-		depth: u32,
-		at: usize,
-		values: TablesRef,
-	) -> Result<()> {
+	pub fn rebalance(&mut self, depth: u32, at: usize, values: TablesRef) -> Result<()> {
 		let has_child = depth - 1 != 0;
 		let middle = ORDER / 2;
 		let mut balance_from_left = false;
@@ -461,11 +451,7 @@ impl Node {
 		}
 	}
 
-	pub fn get(
-		&self,
-		key: &[u8],
-		values: TablesRef,
-	) -> Result<Option<Address>> {
+	pub fn get(&self, key: &[u8], values: TablesRef) -> Result<Option<Address>> {
 		let (at, i) = self.position(key)?;
 		if at {
 			Ok(self.separator_address(i))
@@ -515,11 +501,7 @@ impl Node {
 	}
 
 	#[cfg(test)]
-	pub fn is_balanced(
-		&self,
-		tables: TablesRef,
-		parent_size: usize,
-	) -> Result<bool> {
+	pub fn is_balanced(&self, tables: TablesRef, parent_size: usize) -> Result<bool> {
 		let size = self.number_separator();
 		if parent_size != 0 && size < ORDER / 2 {
 			return Ok(false)
@@ -797,11 +779,7 @@ impl Node {
 		Ok((false, i))
 	}
 
-	pub fn fetch_child(
-		&self,
-		i: usize,
-		values: TablesRef,
-	) -> Result<Option<Self>> {
+	pub fn fetch_child(&self, i: usize, values: TablesRef) -> Result<Option<Self>> {
 		if let Some(ix) = self.children[i].entry_index {
 			let entry = BTreeTable::get_encoded_entry(ix, values)?;
 			return Ok(Some(Self::from_encoded(entry)?))

--- a/src/column.rs
+++ b/src/column.rs
@@ -168,7 +168,7 @@ pub fn hash_key(key: &[u8], salt: &Salt, uniform: bool, db_version: u32) -> Key 
 			#[cfg(any(test, feature = "instrumentation"))]
 			// Used for forcing collisions in tests.
 			if salt == &Salt::default() {
-				k.copy_from_slice(&key);
+				k.copy_from_slice(key);
 				return k
 			}
 			// siphash 1-3 first 128 bits of the key
@@ -177,7 +177,7 @@ pub fn hash_key(key: &[u8], salt: &Salt, uniform: bool, db_version: u32) -> Key 
 			let mut hasher = siphasher::sip128::SipHasher13::new_with_key(
 				salt[..16].try_into().expect("Salt length is 32"),
 			);
-			hasher.write(&key);
+			hasher.write(key);
 			let hash = hasher.finish128();
 			k[0..8].copy_from_slice(&hash.h1.to_le_bytes());
 			k[8..16].copy_from_slice(&hash.h2.to_le_bytes());

--- a/src/column.rs
+++ b/src/column.rs
@@ -635,18 +635,6 @@ impl HashColumn {
 					let mut key = Key::default();
 					log.read(&mut key)?;
 					let len = log.read_u32()?;
-
-					/*
-					let maybe_value = { commit_overlay.read().get_hash_entry(&key, log.record_id()) };
-					if let Some(Some(value)) = maybe_value {
-						log.skip(len as usize)?;
-						if let WriteOutcome::NeedReindex = self.write_plan(&Operation::Set(key, value))? {
-							reindex = true;
-						}
-						commit_overlay.write().remove_hash_entry(&key, log.record_id());
-						continue
-					}*/
-
 					let mut value = Vec::with_capacity(len as usize);
 					unsafe {
 						value.set_len(len as usize);

--- a/src/column.rs
+++ b/src/column.rs
@@ -622,6 +622,7 @@ impl HashColumn {
 		Ok((outcome, tables, reindex))
 	}
 
+	#[allow(clippy::uninit_vec)] // See https://rust-lang.github.io/rfcs/2930-read-buf.html
 	pub fn enact_ops(
 		&self,
 		count: u32,

--- a/src/db.rs
+++ b/src/db.rs
@@ -589,12 +589,6 @@ impl DbInner {
 					}
 					reader.reset()?;
 					reader.next()?;
-					{
-						let mut queue = self.commit_queue.lock();
-						if reader.record_id() >= queue.next_record_id {
-							queue.next_record_id = reader.record_id() + 1;
-						}
-					}
 				}
 				loop {
 					match reader.next()? {

--- a/src/db.rs
+++ b/src/db.rs
@@ -293,9 +293,7 @@ impl DbInner {
 		match &self.columns[col as usize] {
 			Column::Hash(_column) =>
 				Err(Error::InvalidConfiguration("Not a hash column.".to_string())),
-			Column::Tree(column) => {
-				BTreeIterator::new(column, &self.commit_overlay[col as usize])
-			},
+			Column::Tree(column) => BTreeIterator::new(column, &self.commit_overlay[col as usize]),
 		}
 	}
 
@@ -1221,7 +1219,11 @@ pub struct CommitOverlay {
 
 impl CommitOverlay {
 	fn new() -> Self {
-		CommitOverlay { hash_table: Default::default(), btree: Default::default(), last_btree_commit: 0 }
+		CommitOverlay {
+			hash_table: Default::default(),
+			btree: Default::default(),
+			last_btree_commit: 0,
+		}
 	}
 
 	#[cfg(test)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -369,7 +369,6 @@ impl DbInner {
 
 		for (c, iterset) in &commit.btree {
 			let mut commit_overlay = self.commit_overlay[*c as usize].write();
-			commit_overlay.last_btree_commit = record_id;
 			iterset.copy_to_overlay(
 				&mut commit_overlay.btree,
 				record_id,
@@ -1251,6 +1250,10 @@ impl CommitOverlay {
 
 	pub fn last_btree_commit(&self) -> u64 {
 		self.last_btree_commit
+	}
+
+	pub fn set_last_btree_commit(&mut self, id: u64) {
+		self.last_btree_commit = id;
 	}
 
 	pub fn remove_hash_entry(&mut self, key: &Key, record_id: u64) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1304,22 +1304,16 @@ impl CommitOverlay {
 		match &last_key {
 			LastKey::End => self
 				.btree
-				.range::<Vec<u8>, _>(..)
-				.rev()
-				.next()
+				.range::<Vec<u8>, _>(..).next_back()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),
 			LastKey::Start => None,
 			LastKey::At(key) => self
 				.btree
-				.range::<Vec<u8>, _>(..key)
-				.rev()
-				.next()
+				.range::<Vec<u8>, _>(..key).next_back()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),
 			LastKey::Seeked(key) => self
 				.btree
-				.range::<Vec<u8>, _>(..=key)
-				.rev()
-				.next()
+				.range::<Vec<u8>, _>(..=key).next_back()
 				.map(|(k, (_, v))| (k.clone(), v.clone())),
 		}
 	}
@@ -2623,7 +2617,7 @@ mod tests {
 		let mut options_db_files = db_test_file.options(tmp.path(), 2);
 		options_db_files.salt = Some(options_db_files.salt.unwrap_or_default());
 		let mut options_std = EnableCommitPipelineStages::Standard.options(tmp.path(), 2);
-		options_std.salt = options_db_files.salt.clone();
+		options_std.salt = options_db_files.salt;
 
 		let db = Db::open_inner(&options_db_files, OpeningMode::Create).unwrap();
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -448,18 +448,12 @@ impl IndexTable {
 		self.insert_chunk(key_prefix, address, sub_index)
 	}
 
-	fn remove_chunk(&self, key_prefix: u64, sub_index: usize) -> Result<WriteOutcome> {
-		let chunk_index = self.chunk_index(key_prefix);
-		let new_entry = Entry::empty();
-		self.write_entry(chunk_index, Some(sub_index), new_entry)?;
-		log::trace!(target: "parity-db", "{}: Removed at {}.{}", self.id, chunk_index, sub_index);
-		return Ok(WriteOutcome::Written)
-	}
-
-	pub fn write_remove(&self, key: &Key, sub_index: usize) -> Result<WriteOutcome> {
-		log::trace!(target: "parity-db", "{}: Removing {}", self.id, hex(key));
+	pub fn write_remove(&self, key: &Key, sub_index: usize) -> Result<()> {
 		let key_prefix = TableKey::index_from_partial(key);
-		self.remove_chunk(key_prefix, sub_index)
+		let chunk_index = self.chunk_index(key_prefix);
+		self.write_entry(chunk_index, Some(sub_index), Entry::empty())?;
+		log::trace!(target: "parity-db", "{}: Removed {} at {}.{}", self.id, hex(key), chunk_index, sub_index);
+		Ok(())
 	}
 
 	pub fn write_entry(

--- a/src/index.rs
+++ b/src/index.rs
@@ -448,17 +448,11 @@ impl IndexTable {
 		self.insert_chunk(key_prefix, address, sub_index)
 	}
 
-	fn remove_chunk(
-		&self,
-		key_prefix: u64,
-		sub_index: usize,
-	) -> Result<WriteOutcome> {
+	fn remove_chunk(&self, key_prefix: u64, sub_index: usize) -> Result<WriteOutcome> {
 		let chunk_index = self.chunk_index(key_prefix);
-
-		let i = sub_index;
 		let new_entry = Entry::empty();
-		self.write_entry(chunk_index, Some(i), new_entry)?;
-		log::trace!(target: "parity-db", "{}: Removed at {}.{}", self.id, chunk_index, i);
+		self.write_entry(chunk_index, Some(sub_index), new_entry)?;
+		log::trace!(target: "parity-db", "{}: Removed at {}.{}", self.id, chunk_index, sub_index);
 		return Ok(WriteOutcome::Written)
 	}
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -510,8 +510,7 @@ impl IndexTable {
 		let offset = META_SIZE + index as usize * CHUNK_LEN;
 		// Nasty mutable pointer cast. We do ensure that all chunks that are being written are
 		// accessed through the overlay in other threads.
-		let ptr: *mut [u8; CHUNK_LEN] =
-			unsafe { map.as_ptr().add(offset) as *mut [u8; CHUNK_LEN] };
+		let ptr: *mut [u8; CHUNK_LEN] = unsafe { map.as_ptr().add(offset) as *mut [u8; CHUNK_LEN] };
 		let chunk: &mut [u8; CHUNK_LEN] = unsafe { ptr.as_mut().unwrap() };
 		if let Some(i) = sub_index {
 			Self::place_entry(&entry, i, chunk);

--- a/src/index.rs
+++ b/src/index.rs
@@ -511,7 +511,7 @@ impl IndexTable {
 		// Nasty mutable pointer cast. We do ensure that all chunks that are being written are
 		// accessed through the overlay in other threads.
 		let ptr: *mut [u8; CHUNK_LEN] =
-			unsafe { map.as_ptr().offset(offset as isize) as *mut [u8; CHUNK_LEN] };
+			unsafe { map.as_ptr().add(offset) as *mut [u8; CHUNK_LEN] };
 		let chunk: &mut [u8; CHUNK_LEN] = unsafe { ptr.as_mut().unwrap() };
 		if let Some(i) = sub_index {
 			Self::place_entry(&entry, i, chunk);

--- a/src/log.rs
+++ b/src/log.rs
@@ -4,17 +4,17 @@
 use crate::{
 	column::ColId,
 	error::{try_io, Error, Result},
-	index::{Chunk as IndexChunk, TableId as IndexTableId, ENTRY_BYTES},
+	index::TableId as IndexTableId,
 	options::Options,
 	parking_lot::{RwLock, RwLockWriteGuard},
-	table::TableId as ValueTableId,
+	table::TableId as ValueTableId, Operation, db::Commit,
 };
 use std::{
 	cmp::min,
-	collections::{HashMap, VecDeque},
+	collections::VecDeque,
 	convert::TryInto,
 	io::{ErrorKind, Read, Seek, Write},
-	sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
+	sync::atomic::{AtomicBool, AtomicU32, Ordering},
 };
 
 const MAX_LOG_POOL_SIZE: usize = 16;
@@ -23,13 +23,10 @@ const INSERT_INDEX: u8 = 2;
 const INSERT_VALUE: u8 = 3;
 const END_RECORD: u8 = 4;
 const DROP_TABLE: u8 = 5;
-
-// Once index overly uses less than 1/10 of its capacity, it will be reclaimed.
-const INDEX_OVERLAY_RECLAIM_FACTOR: usize = 10;
-// Once value overly uses less than 1/10 of its capacity, it will be reclaimed.
-const VALUE_OVERLAY_RECLAIM_FACTOR: usize = 10;
-// Min number of value items to initiate reclaim. Each item is around 40 bytes.
-const VALUE_OVERLAY_MIN_RECLAIM_ITEMS: usize = 10240;
+const SET: u8 = 6;
+const REFERENCE: u8 = 7;
+const DEREFERENCE: u8 = 8;
+const COLUMN_OPS: u8 = 9;
 
 #[derive(Debug)]
 pub struct InsertIndexAction {
@@ -49,28 +46,16 @@ pub enum LogAction {
 	InsertIndex(InsertIndexAction),
 	InsertValue(InsertValueAction),
 	DropTable(IndexTableId),
+	ColumnOps((ColId, u32)),
 	EndRecord,
+	Set,
+	Reference,
+	Dereference,
 }
 
-pub trait LogQuery {
-	type ValueRef<'a>: std::ops::Deref<Target = [u8]>
-	where
-		Self: 'a;
-
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
-		&self,
-		table: IndexTableId,
-		index: u64,
-		f: F,
-	) -> Option<R>;
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool;
-	fn value_ref<'a>(&'a self, table: ValueTableId, index: u64) -> Option<Self::ValueRef<'a>>;
-}
 
 #[derive(Debug)]
 pub struct LogOverlays {
-	index: Vec<IndexLogOverlay>,
-	value: Vec<ValueLogOverlay>,
 	last_record_ids: Vec<u64>,
 }
 
@@ -81,110 +66,9 @@ impl LogOverlays {
 
 	pub fn with_columns(count: usize) -> Self {
 		Self {
-			index: (0..IndexTableId::max_log_indicies(count))
-				.map(|_| IndexLogOverlay::default())
-				.collect(),
-			value: (0..ValueTableId::max_log_tables(count))
-				.map(|_| ValueLogOverlay::default())
-				.collect(),
 			last_record_ids: (0..count).map(|_| 0).collect(),
 		}
 	}
-}
-
-// Loom is missing support for guard projection, so we copy the data as a workaround.
-#[cfg(feature = "loom")]
-pub struct MappedBytesGuard<'a> {
-	_phantom: std::marker::PhantomData<&'a ()>,
-	data: Vec<u8>,
-}
-
-#[cfg(feature = "loom")]
-impl<'a> MappedBytesGuard<'a> {
-	fn new(data: Vec<u8>) -> Self {
-		Self { _phantom: std::marker::PhantomData, data }
-	}
-}
-
-#[cfg(feature = "loom")]
-impl<'a> std::ops::Deref for MappedBytesGuard<'a> {
-	type Target = [u8];
-
-	fn deref(&self) -> &Self::Target {
-		self.data.as_slice()
-	}
-}
-
-#[cfg(not(feature = "loom"))]
-type MappedBytesGuard<'a> = parking_lot::MappedRwLockReadGuard<'a, [u8]>;
-
-impl LogQuery for RwLock<LogOverlays> {
-	type ValueRef<'a> = MappedBytesGuard<'a>;
-
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
-		&self,
-		table: IndexTableId,
-		index: u64,
-		f: F,
-	) -> Option<R> {
-		(&*self.read()).with_index(table, index, f)
-	}
-
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool {
-		(&*self.read()).value(table, index, dest)
-	}
-
-	#[cfg(not(feature = "loom"))]
-	fn value_ref<'a>(&'a self, table: ValueTableId, index: u64) -> Option<Self::ValueRef<'a>> {
-		let lock =
-			parking_lot::RwLockReadGuard::try_map(self.read(), |o| o.value_ref(table, index));
-		lock.ok()
-	}
-
-	#[cfg(feature = "loom")]
-	fn value_ref<'a>(&'a self, table: ValueTableId, index: u64) -> Option<Self::ValueRef<'a>> {
-		self.read().value_ref(table, index).map(|o| MappedBytesGuard::new(o.to_vec()))
-	}
-}
-
-impl LogQuery for LogOverlays {
-	type ValueRef<'a> = &'a [u8];
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
-		&self,
-		table: IndexTableId,
-		index: u64,
-		f: F,
-	) -> Option<R> {
-		self.index
-			.get(table.log_index())
-			.and_then(|o| o.map.get(&index).map(|(_id, _mask, data)| f(data)))
-	}
-
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool {
-		let s = self;
-		if let Some(d) = s
-			.value
-			.get(table.log_index())
-			.and_then(|o| o.map.get(&index).map(|(_id, data)| data))
-		{
-			let len = dest.len().min(d.len());
-			dest[0..len].copy_from_slice(&d[0..len]);
-			true
-		} else {
-			false
-		}
-	}
-	fn value_ref<'a>(&'a self, table: ValueTableId, index: u64) -> Option<Self::ValueRef<'a>> {
-		self.value
-			.get(table.log_index())
-			.and_then(|o| o.map.get(&index).map(|(_id, data)| data.as_slice()))
-	}
-}
-
-#[derive(Debug, Default)]
-pub struct Cleared {
-	index: Vec<(IndexTableId, u64)>,
-	values: Vec<(ValueTableId, u64)>,
 }
 
 #[derive(Debug)]
@@ -194,7 +78,6 @@ pub struct LogReader<'a> {
 	read_bytes: u64,
 	crc32: crc32fast::Hasher,
 	validate: bool,
-	cleared: Cleared,
 }
 
 impl<'a> LogReader<'a> {
@@ -204,7 +87,6 @@ impl<'a> LogReader<'a> {
 
 	fn new(reading: RwLockWriteGuard<'a, Option<Reading>>, validate: bool) -> LogReader<'a> {
 		LogReader {
-			cleared: Default::default(),
 			reading,
 			record_id: 0,
 			read_bytes: 0,
@@ -214,7 +96,6 @@ impl<'a> LogReader<'a> {
 	}
 
 	pub fn reset(&mut self) -> Result<()> {
-		self.cleared = Default::default();
 		try_io!(self
 			.reading
 			.as_mut()
@@ -252,7 +133,6 @@ impl<'a> LogReader<'a> {
 					IndexTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
 				read_buf(8, &mut buf)?;
 				let index = u64::from_le_bytes(buf);
-				self.cleared.index.push((table, index));
 				Ok(LogAction::InsertIndex(InsertIndexAction { table, index }))
 			},
 			INSERT_VALUE => {
@@ -261,7 +141,6 @@ impl<'a> LogReader<'a> {
 					ValueTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
 				read_buf(8, &mut buf)?;
 				let index = u64::from_le_bytes(buf);
-				self.cleared.values.push((table, index));
 				Ok(LogAction::InsertValue(InsertValueAction { table, index }))
 			},
 			END_RECORD => {
@@ -289,6 +168,22 @@ impl<'a> LogReader<'a> {
 					IndexTableId::from_u16(u16::from_le_bytes(buf[0..2].try_into().unwrap()));
 				Ok(LogAction::DropTable(table))
 			},
+			COLUMN_OPS => {
+				read_buf(1, &mut buf)?;
+				let col = u8::from_le_bytes(buf[0..1].try_into().unwrap());
+				read_buf(4, &mut buf)?;
+				let count = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+				Ok(LogAction::ColumnOps((col, count)))
+			},
+			SET => {
+				Ok(LogAction::Set)
+			},
+			REFERENCE => {
+				Ok(LogAction::Reference)
+			},
+			DEREFERENCE => {
+				Ok(LogAction::Dereference)
+			}
 			_ => Err(Error::Corruption("Bad log entry type".into())),
 		}
 	}
@@ -302,258 +197,32 @@ impl<'a> LogReader<'a> {
 		Ok(())
 	}
 
-	pub fn drain(self) -> Cleared {
-		self.cleared
+	pub fn skip(&mut self, len: usize) -> Result<()> {
+		let mut remaining = len;
+		if self.validate {
+			while remaining != 0 {
+				let mut buf = [0u8; 4096];
+				let read_to = &mut buf[0..std::cmp::min(remaining, 4096)];
+				try_io!(self.reading.as_mut().unwrap().file.read_exact(read_to));
+				self.crc32.update(read_to);
+				remaining -= read_to.len();
+			}
+		} else {
+			try_io!(self.reading.as_mut().unwrap().file.seek(std::io::SeekFrom::Current(len as i64)));
+		}
+		self.read_bytes += len as u64;
+		Ok(())
+	}
+
+	pub fn read_u32(&mut self) -> Result<u32> {
+		let mut buf = [0u8; 4];
+		self.read(&mut buf)?;
+		Ok(u32::from_le_bytes(buf))
 	}
 
 	pub fn read_bytes(&self) -> u64 {
 		self.read_bytes
 	}
-}
-
-#[derive(Debug)]
-pub struct LogChange {
-	local_index: HashMap<IndexTableId, IndexLogOverlay>,
-	local_values: HashMap<ValueTableId, ValueLogOverlayLocal>,
-	record_id: u64,
-	dropped_tables: Vec<IndexTableId>,
-}
-
-impl LogChange {
-	fn new(record_id: u64) -> LogChange {
-		LogChange {
-			local_index: Default::default(),
-			local_values: Default::default(),
-			dropped_tables: Default::default(),
-			record_id,
-		}
-	}
-
-	pub fn local_values_changes(&self, id: ValueTableId) -> Option<&ValueLogOverlayLocal> {
-		self.local_values.get(&id)
-	}
-
-	fn flush_to_file(self, file: &mut std::io::BufWriter<std::fs::File>) -> Result<FlushedLog> {
-		let mut crc32 = crc32fast::Hasher::new();
-		let mut bytes: u64 = 0;
-
-		let mut write = |buf: &[u8]| -> Result<()> {
-			try_io!(file.write_all(buf));
-			crc32.update(buf);
-			bytes += buf.len() as u64;
-			Ok(())
-		};
-
-		write(&BEGIN_RECORD.to_le_bytes())?;
-		write(&self.record_id.to_le_bytes())?;
-
-		for (id, overlay) in self.local_index.iter() {
-			for (index, (_, modified_entries_mask, chunk)) in overlay.map.iter() {
-				write(INSERT_INDEX.to_le_bytes().as_ref())?;
-				write(&id.as_u16().to_le_bytes())?;
-				write(&index.to_le_bytes())?;
-				write(&modified_entries_mask.to_le_bytes())?;
-				let mut mask = *modified_entries_mask;
-				while mask != 0 {
-					let i = mask.trailing_zeros();
-					mask &= !(1 << i);
-					write(&chunk[i as usize * ENTRY_BYTES..(i as usize + 1) * ENTRY_BYTES])?;
-				}
-			}
-		}
-		for (id, overlay) in self.local_values.iter() {
-			for (index, (_, value)) in overlay.map.iter() {
-				write(INSERT_VALUE.to_le_bytes().as_ref())?;
-				write(&id.as_u16().to_le_bytes())?;
-				write(&index.to_le_bytes())?;
-				write(value)?;
-			}
-		}
-		for id in self.dropped_tables.iter() {
-			log::debug!(target: "parity-db", "Finalizing drop {}", id);
-			write(DROP_TABLE.to_le_bytes().as_ref())?;
-			write(&id.as_u16().to_le_bytes())?;
-		}
-		write(&END_RECORD.to_le_bytes())?;
-		let checksum: u32 = crc32.finalize();
-		try_io!(file.write_all(&checksum.to_le_bytes()));
-		bytes += 4;
-		try_io!(file.flush());
-		Ok(FlushedLog { index: self.local_index, values: self.local_values, bytes })
-	}
-}
-
-#[derive(Debug)]
-struct FlushedLog {
-	index: HashMap<IndexTableId, IndexLogOverlay>,
-	values: HashMap<ValueTableId, ValueLogOverlayLocal>,
-	bytes: u64,
-}
-
-#[derive(Debug)]
-pub struct LogWriter<'a> {
-	overlays: &'a RwLock<LogOverlays>,
-	log: LogChange,
-}
-
-impl<'a> LogWriter<'a> {
-	pub fn new(overlays: &'a RwLock<LogOverlays>, record_id: u64) -> LogWriter<'a> {
-		LogWriter { overlays, log: LogChange::new(record_id) }
-	}
-
-	pub fn record_id(&self) -> u64 {
-		self.log.record_id
-	}
-
-	pub fn insert_index(&mut self, table: IndexTableId, index: u64, sub: u8, data: &IndexChunk) {
-		match self.log.local_index.entry(table).or_default().map.entry(index) {
-			std::collections::hash_map::Entry::Occupied(mut entry) => {
-				*entry.get_mut() = (self.log.record_id, entry.get().1 | (1 << sub), *data);
-			},
-			std::collections::hash_map::Entry::Vacant(entry) => {
-				entry.insert((self.log.record_id, 1 << sub, *data));
-			},
-		}
-	}
-
-	pub fn insert_value(&mut self, table: ValueTableId, index: u64, data: Vec<u8>) {
-		self.log
-			.local_values
-			.entry(table)
-			.or_default()
-			.map
-			.insert(index, (self.log.record_id, data));
-	}
-
-	pub fn drop_table(&mut self, id: IndexTableId) {
-		self.log.dropped_tables.push(id);
-	}
-
-	pub fn drain(self) -> LogChange {
-		self.log
-	}
-}
-
-pub enum LogWriterValueGuard<'a> {
-	Local(&'a [u8]),
-	Overlay(MappedBytesGuard<'a>),
-}
-
-impl std::ops::Deref for LogWriterValueGuard<'_> {
-	type Target = [u8];
-	fn deref(&self) -> &[u8] {
-		match self {
-			LogWriterValueGuard::Local(data) => data,
-			LogWriterValueGuard::Overlay(data) => data.deref(),
-		}
-	}
-}
-
-impl<'q> LogQuery for LogWriter<'q> {
-	type ValueRef<'a> = LogWriterValueGuard<'a> where Self: 'a;
-	fn with_index<R, F: FnOnce(&IndexChunk) -> R>(
-		&self,
-		table: IndexTableId,
-		index: u64,
-		f: F,
-	) -> Option<R> {
-		match self
-			.log
-			.local_index
-			.get(&table)
-			.and_then(|o| o.map.get(&index).map(|(_id, _mask, data)| data))
-		{
-			Some(data) => Some(f(data)),
-			None => self.overlays.with_index(table, index, f),
-		}
-	}
-
-	fn value(&self, table: ValueTableId, index: u64, dest: &mut [u8]) -> bool {
-		if let Some(d) = self
-			.log
-			.local_values
-			.get(&table)
-			.and_then(|o| o.map.get(&index).map(|(_id, data)| data))
-		{
-			let len = dest.len().min(d.len());
-			dest[0..len].copy_from_slice(&d[0..len]);
-			true
-		} else {
-			self.overlays.value(table, index, dest)
-		}
-	}
-	fn value_ref<'v>(&'v self, table: ValueTableId, index: u64) -> Option<Self::ValueRef<'v>> {
-		self.log
-			.local_values
-			.get(&table)
-			.and_then(|o| {
-				o.map.get(&index).map(|(_id, data)| LogWriterValueGuard::Local(data.as_slice()))
-			})
-			.or_else(|| {
-				self.overlays
-					.value_ref(table, index)
-					.map(|data| LogWriterValueGuard::Overlay(data))
-			})
-	}
-}
-
-// Identity hash.
-#[derive(Debug, Default, Clone)]
-pub struct IdentityHash(u64);
-pub type BuildIdHash = std::hash::BuildHasherDefault<IdentityHash>;
-
-impl std::hash::Hasher for IdentityHash {
-	fn write(&mut self, _: &[u8]) {
-		unreachable!()
-	}
-	fn write_u8(&mut self, _: u8) {
-		unreachable!()
-	}
-	fn write_u16(&mut self, _: u16) {
-		unreachable!()
-	}
-	fn write_u32(&mut self, _: u32) {
-		unreachable!()
-	}
-	fn write_u64(&mut self, n: u64) {
-		self.0 = n
-	}
-	fn write_usize(&mut self, _: usize) {
-		unreachable!()
-	}
-	fn write_i8(&mut self, _: i8) {
-		unreachable!()
-	}
-	fn write_i16(&mut self, _: i16) {
-		unreachable!()
-	}
-	fn write_i32(&mut self, _: i32) {
-		unreachable!()
-	}
-	fn write_i64(&mut self, _: i64) {
-		unreachable!()
-	}
-	fn write_isize(&mut self, _: isize) {
-		unreachable!()
-	}
-	fn finish(&self) -> u64 {
-		self.0
-	}
-}
-
-#[derive(Debug, Default)]
-pub struct IndexLogOverlay {
-	pub map: HashMap<u64, (u64, u64, IndexChunk)>, // index -> (record_id, modified_mask, entry)
-}
-
-// We use identity hash for value overlay/log records so that writes to value tables are in order.
-#[derive(Debug, Default)]
-pub struct ValueLogOverlay {
-	pub map: HashMap<u64, (u64, Vec<u8>)>, // index -> (record_id, entry)
-}
-#[derive(Debug, Default)]
-pub struct ValueLogOverlayLocal {
-	pub map: HashMap<u64, (u64, Vec<u8>), BuildIdHash>, // index -> (record_id, entry)
 }
 
 #[derive(Debug)]
@@ -575,7 +244,6 @@ pub struct Log {
 	appending: RwLock<Option<Appending>>,
 	reading: RwLock<Option<Reading>>,
 	read_queue: RwLock<VecDeque<(u32, std::fs::File)>>,
-	next_record_id: AtomicU64,
 	dirty: AtomicBool,
 	log_pool: RwLock<VecDeque<(u32, std::fs::File)>>,
 	cleanup_queue: RwLock<VecDeque<(u32, std::fs::File)>>,
@@ -620,7 +288,6 @@ impl Log {
 			appending: RwLock::new(None),
 			reading: RwLock::new(None),
 			read_queue: RwLock::default(),
-			next_record_id: AtomicU64::new(1),
 			next_log_id: AtomicU32::new(next_log_id),
 			dirty: AtomicBool::new(true),
 			sync: options.sync_wal,
@@ -681,26 +348,14 @@ impl Log {
 			self.cleanup_queue.write().push_back((id, file));
 		}
 		let mut overlays = self.overlays.write();
-		for o in overlays.index.iter_mut() {
-			o.map.clear();
-		}
-		for o in overlays.value.iter_mut() {
-			o.map.clear();
-		}
 		for r in overlays.last_record_ids.iter_mut() {
 			*r = 0;
 		}
 		self.dirty.store(false, Ordering::Relaxed);
 	}
 
-	pub fn begin_record(&self) -> LogWriter<'_> {
-		let id = self.next_record_id.fetch_add(1, Ordering::Relaxed);
-		LogWriter::new(&self.overlays, id)
-	}
-
-	pub fn end_record(&self, log: LogChange) -> Result<u64> {
-		assert_eq!(log.record_id + 1, self.next_record_id.load(Ordering::Relaxed));
-		let record_id = log.record_id;
+	pub fn write_commit(&self, commit: &Commit) -> Result<u64> {
+		let record_id = commit.id;
 		let mut appending = self.appending.write();
 		if appending.is_none() {
 			// Find a log file in the pool or create a new one
@@ -722,80 +377,101 @@ impl Log {
 			*appending = Some(Appending { size: 0, file: std::io::BufWriter::new(file), id });
 		}
 		let appending = appending.as_mut().unwrap();
-		let FlushedLog { index, values, bytes } = log.flush_to_file(&mut appending.file)?;
+		let bytes = Self::write_commit_to_file(&mut appending.file, commit)?;
 		let mut overlays = self.overlays.write();
-		let mut total_index = 0;
-		for (id, overlay) in index.into_iter() {
-			total_index += overlay.map.len();
-			overlays.index[id.log_index()].map.extend(overlay.map.into_iter());
-		}
-		let mut total_value = 0;
-		for (id, overlay) in values.into_iter() {
-			total_value += overlay.map.len();
-			overlays.last_record_ids[id.col() as usize] = record_id;
-			overlays.value[id.log_index()].map.extend(overlay.map.into_iter());
+
+		for (c, _) in commit.changeset.btree_indexed.iter() {
+			overlays.last_record_ids[*c as usize] = commit.id;
 		}
 
 		log::debug!(
 			target: "parity-db",
-			"Finalizing log record {} ({} index, {} value)",
+			"Finalizing log record {} ({} bytes)",
 			record_id,
-			total_index,
-			total_value,
+			bytes,
 		);
 		appending.size += bytes;
 		self.dirty.store(true, Ordering::Relaxed);
 		Ok(bytes)
 	}
 
-	pub fn end_read(&self, cleared: Cleared, record_id: u64) {
-		if record_id >= self.next_record_id.load(Ordering::Relaxed) {
-			self.next_record_id.store(record_id + 1, Ordering::Relaxed);
-		}
-		let mut overlays = self.overlays.write();
-		for (table, index) in cleared.index.into_iter() {
-			if let Some(ref mut overlay) = overlays.index.get_mut(table.log_index()) {
-				if let std::collections::hash_map::Entry::Occupied(e) = overlay.map.entry(index) {
-					if e.get().0 == record_id {
-						e.remove_entry();
-					}
+	fn write_commit_to_file(file: &mut std::io::BufWriter<std::fs::File>, commit: &Commit) -> Result<u64> {
+		let mut crc32 = crc32fast::Hasher::new();
+		let mut bytes: u64 = 0;
+
+		let mut write = |buf: &[u8]| -> Result<()> {
+			try_io!(file.write_all(buf));
+			crc32.update(buf);
+			bytes += buf.len() as u64;
+			Ok(())
+		};
+
+		write(&BEGIN_RECORD.to_le_bytes())?;
+		write(&commit.id.to_le_bytes())?;
+
+		for (col, changeset) in &commit.changeset.indexed {
+			write(COLUMN_OPS.to_le_bytes().as_ref())?;
+			write(col.to_le_bytes().as_ref())?;
+			let count = changeset.changes.len() as u32;
+			write(&count.to_le_bytes())?;
+			for change in &changeset.changes {
+				match change {
+					Operation::Set(key, value) => {
+						write(SET.to_le_bytes().as_ref())?;
+						write(key)?;
+						let len = value.as_ref().len() as u32;
+						write(&len.to_le_bytes())?;
+						write(value.as_ref())?;
+					},
+					Operation::Reference(key) => {
+						write(REFERENCE.to_le_bytes().as_ref())?;
+						write(key)?;
+					},
+					Operation::Dereference(key) => {
+						write(DEREFERENCE.to_le_bytes().as_ref())?;
+						write(key)?;
+					},
 				}
 			}
 		}
-		for (table, index) in cleared.values.into_iter() {
-			if let Some(ref mut overlay) = overlays.value.get_mut(table.log_index()) {
-				if let std::collections::hash_map::Entry::Occupied(e) = overlay.map.entry(index) {
-					if e.get().0 == record_id {
-						e.remove_entry();
-					}
+		for (col, changeset) in &commit.changeset.btree_indexed {
+			write(COLUMN_OPS.to_le_bytes().as_ref())?;
+			write(col.to_le_bytes().as_ref())?;
+			let count = changeset.changes.len() as u32;
+			write(&count.to_le_bytes())?;
+			for change in &changeset.changes {
+				match change {
+					Operation::Set(key, value) => {
+						write(SET.to_le_bytes().as_ref())?;
+						let len = key.as_ref().len() as u32;
+						write(&len.to_le_bytes())?;
+						write(key.as_ref())?;
+						let len = value.as_ref().len() as u32;
+						write(&len.to_le_bytes())?;
+						write(value.as_ref())?;
+					},
+					Operation::Reference(key) => {
+						write(REFERENCE.to_le_bytes().as_ref())?;
+						let len = key.as_ref().len() as u32;
+						write(&len.to_le_bytes())?;
+						write(key.as_ref())?;
+					},
+					Operation::Dereference(key) => {
+						write(DEREFERENCE.to_le_bytes().as_ref())?;
+						let len = key.as_ref().len() as u32;
+						write(&len.to_le_bytes())?;
+						write(key.as_ref())?;
+					},
 				}
 			}
 		}
-		// Reclaim overlay memory
-		for (i, o) in overlays.index.iter_mut().enumerate() {
-			if o.map.capacity() > o.map.len() * INDEX_OVERLAY_RECLAIM_FACTOR {
-				log::trace!(
-					"Schrinking index overlay {}: {}/{}",
-					IndexTableId::from_log_index(i),
-					o.map.len(),
-					o.map.capacity(),
-				);
-				o.map.shrink_to_fit();
-			}
-		}
-		for (i, o) in overlays.value.iter_mut().enumerate() {
-			if o.map.capacity() > VALUE_OVERLAY_MIN_RECLAIM_ITEMS &&
-				o.map.capacity() > o.map.len() * VALUE_OVERLAY_RECLAIM_FACTOR
-			{
-				log::trace!(
-					"Schrinking value overlay {}: {}/{}",
-					ValueTableId::from_log_index(i),
-					o.map.len(),
-					o.map.capacity(),
-				);
-				o.map.shrink_to_fit();
-			}
-		}
+
+		write(&END_RECORD.to_le_bytes())?;
+		let checksum: u32 = crc32.finalize();
+		try_io!(file.write_all(&checksum.to_le_bytes()));
+		bytes += 4;
+		try_io!(file.flush());
+		Ok(bytes)
 	}
 
 	pub fn flush_one(&self, min_size: u64) -> Result<bool> {

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -3,7 +3,7 @@
 
 use crate::{
 	column::{ColId, IterState},
-	db::{CommitChangeSet, Db, IndexedChangeSet, Operation},
+	db::{CommitChangeSet, Db, HashTableChangeSet, Operation},
 	error::try_io,
 	options::Options,
 	Error, Result,
@@ -83,9 +83,9 @@ pub fn migrate(from: &Path, mut to: Options, overwrite: bool, force_migrate: &[u
 				for _ in 0..rc {
 					let value = std::mem::take(&mut value);
 					commit
-						.indexed
+						.hash_table
 						.entry(c)
-						.or_insert_with(|| IndexedChangeSet::new(c))
+						.or_insert_with(|| HashTableChangeSet::new(c))
 						.changes
 						.push(Operation::Set(key, value.into()));
 					nb_commit += 1;

--- a/src/options.rs
+++ b/src/options.rs
@@ -9,9 +9,10 @@ use crate::{
 use rand::Rng;
 use std::{collections::HashMap, path::Path};
 
-pub const CURRENT_VERSION: u32 = 8;
+pub const CURRENT_VERSION: u32 = 9;
 // TODO on last supported 5, remove MULTIHEAD_V4 and MULTIPART_V4
 // TODO on last supported 8, remove XOR with salt in column::hash
+// TODO on last supported 9, remove *_legacy_* log record support.
 const LAST_SUPPORTED_VERSION: u32 = 4;
 
 pub const DEFAULT_COMPRESSION_THRESHOLD: u32 = 4096;

--- a/src/table.rs
+++ b/src/table.rs
@@ -1061,7 +1061,7 @@ pub mod key {
 			}
 		}
 
-		pub fn fetch_partial<'a>(buf: &mut EntryRef<'a>) -> Result<[u8; PARTIAL_SIZE]> {
+		pub fn fetch_partial(buf: &mut EntryRef<'_>) -> Result<[u8; PARTIAL_SIZE]> {
 			let mut result = [0u8; PARTIAL_SIZE];
 			if buf.1.len() >= PARTIAL_SIZE {
 				let pks = buf.read_partial();
@@ -1071,7 +1071,7 @@ pub mod key {
 			Err(crate::error::Error::InvalidValueData)
 		}
 
-		pub fn fetch<'a>(&self, buf: &mut EntryRef<'a>) -> Result<Option<[u8; PARTIAL_SIZE]>> {
+		pub fn fetch(&self, buf: &mut EntryRef<'_>) -> Result<Option<[u8; PARTIAL_SIZE]>> {
 			match self {
 				TableKey::Partial(_k) => Ok(Some(Self::fetch_partial(buf)?)),
 				TableKey::NoHash => Ok(None),
@@ -1344,7 +1344,7 @@ mod test {
 				];
 
 				for (k, v) in &entries {
-					table.write_insert(k, &v, compressed).unwrap();
+					table.write_insert(k, v, compressed).unwrap();
 				}
 
 				let mut res = Vec::new();


### PR DESCRIPTION
This introduce a major chage in the WAL format. Current design writes WAL in the format that matches the on-disk format. I.e. index pages and value table entries. This seemed like a good idea at the time, as it allowed to split the work more efficiently between threads, and incorporate the reindex process. However it turned out that this approach has some drawbacks:

1. Log records are bigger in size. Write amplification is high.
2. Possibility of page evicton. There's significant time between planning and enactment phases. Planning phase would load a page from disk into OS page cache (to e.g. check if the key matches), and write an update to the log. By the time that log is eanced the OS might have already evicted the page and would need to load it again.

This new design changes the log records to contain high level DB operations, rather than the low level table updates. Operations are now executed at the enactment phase. `CommitOverlay` holds newly inserted key-values until they are enacted.
