### PR TITLE
CI for windows and macos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,10 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-13-xl, windows-2022]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1

--- a/src/file.rs
+++ b/src/file.rs
@@ -93,7 +93,6 @@ impl TableFile {
 				capacity = len / entry_size as u64;
 			}
 			let mut map = mmap(&file, len as usize)?;
-			madvise_random(&mut map);
 			Some((map, file))
 		} else {
 			None

--- a/src/file.rs
+++ b/src/file.rs
@@ -53,6 +53,25 @@ pub fn madvise_random(map: &mut memmap2::MmapMut) {
 #[cfg(not(unix))]
 pub fn madvise_random(_map: &mut memmap2::MmapMut) {}
 
+
+#[cfg(not(windows))]
+fn mmap(file: &std::fs::File, len: usize) -> Result<memmap2::MmapMut> {
+	let map_len = len + RESERVE_ADDRESS_SPACE;
+	let mut map = try_io!(unsafe {
+		memmap2::MmapOptions::new().len(map_len).map_mut(file)
+	});
+	madvise_random(&mut map);
+	Ok(map)
+}
+
+#[cfg(windows)]
+fn mmap(file: &std::fs::File, _len: usize) -> Result<memmap2::MmapMut> {
+	let mut map = try_io!(unsafe {
+		memmap2::MmapOptions::new().map_mut(file)
+	});
+	Ok(map)
+}
+
 const GROW_SIZE_BYTES: u64 = 256 * 1024;
 
 #[derive(Debug)]
@@ -61,10 +80,6 @@ pub struct TableFile {
 	pub path: std::path::PathBuf,
 	pub capacity: AtomicU64,
 	pub id: TableId,
-}
-
-fn map_len(file_len: u64) -> usize {
-	file_len as usize + RESERVE_ADDRESS_SPACE
 }
 
 impl TableFile {
@@ -84,8 +99,7 @@ impl TableFile {
 			} else {
 				capacity = len / entry_size as u64;
 			}
-			let mut map =
-				try_io!(unsafe { memmap2::MmapOptions::new().len(map_len(len)).map_mut(&file) });
+			let mut map = mmap(&file, len as usize)?;
 			madvise_random(&mut map);
 			Some((map, file))
 		} else {
@@ -152,10 +166,7 @@ impl TableFile {
 				let file = self.create_file()?;
 				let len = GROW_SIZE_BYTES;
 				try_io!(file.set_len(len));
-				let mut map = try_io!(unsafe {
-					memmap2::MmapOptions::new().len(RESERVE_ADDRESS_SPACE).map_mut(&file)
-				});
-				madvise_random(&mut map);
+				let map = mmap(&file, 0)?;
 				*map_and_file = Some((map, file));
 				len
 			},
@@ -163,10 +174,7 @@ impl TableFile {
 				let new_len = try_io!(file.metadata()).len() + GROW_SIZE_BYTES;
 				try_io!(file.set_len(new_len));
 				if map.len() < new_len as usize {
-					let mut new_map = try_io!(unsafe {
-						memmap2::MmapOptions::new().len(map_len(new_len)).map_mut(&*file)
-					});
-					madvise_random(&mut new_map);
+					let new_map = mmap(&file, new_len as usize)?;
 					let old_map = std::mem::replace(map, new_map);
 					try_io!(old_map.flush());
 					// Leak the old mapping as there might be concurrent readers.


### PR DESCRIPTION
Disable mmap address space reservation on windows as it is not supported by memmap2-rs