### PR TITLE
Add support for LoongArch64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ pub use stats::{ColumnStatSummary, StatSummary};
 pub const KEY_SIZE: usize = 32;
 pub type Key = [u8; KEY_SIZE];
 
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-compile_error!("parity-db only supports x86_64 and aarch64");
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "loongarch64")))]
+compile_error!("parity-db only supports x86_64, aarch64 and loongarch64 (unofficially)");
 
 #[cfg(not(target_endian = "little"))]
 compile_error!("parity-db only supports little-endian platforms");


### PR DESCRIPTION
Add support for [LoongArch64](https://doc.rust-lang.org/rustc/platform-support/loongarch-linux.html) (A tier-2 with host tools target).