### PR TITLE
Disable read-ahead on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ snap = "1"
 loom = { version = "0.5.1", optional = true }
 siphasher = "0.3.10"
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.9"
+
 [dev-dependencies]
 env_logger = { version = "0.10.0", default-features = false, features = ["auto-color", "humantime"] }
 fdlimit = "0.2.1"


### PR DESCRIPTION
Windows requires custom options to be specified instead of doing this on a file handle