### PR TITLE
file size limit?

### DIFF
--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -34,6 +34,7 @@ pub fn run() -> Result<(), String> {
 		let mut options = parity_db::Options::with_columns(db_path.as_path(), 0);
 		options.columns = metadata.columns;
 		options.salt = Some(metadata.salt);
+		options.max_file_size = metadata.max_file_size;
 		options
 	} else {
 		let mut options = parity_db::Options::with_columns(db_path.as_path(), nb_column);
@@ -47,6 +48,7 @@ pub fn run() -> Result<(), String> {
 	options.sync_wal = !cli.shared().no_sync;
 	options.sync_data = !cli.shared().no_sync;
 	options.stats = cli.shared().with_stats;
+	options.max_file_size = cli.shared().max_file_size;
 	log::debug!("Options: {:?}, {:?}", cli, options);
 	match cli.subcommand {
 		SubCommand::Stats(stat) => {
@@ -184,6 +186,10 @@ pub struct Shared {
 	/// Register stat from those admin operations.
 	#[clap(long)]
 	pub with_stats: bool,
+
+	/// If define use multiple files with a size limit. May have effect on performance.
+	#[clap(long)]
+	pub max_file_size: Option<usize>,
 
 	/// Indicate the number of column, when using
 	/// a new or temporary db, defaults to one.

--- a/src/db.rs
+++ b/src/db.rs
@@ -2337,6 +2337,7 @@ mod tests {
 				sync_wal: true,
 				sync_data: true,
 				stats: true,
+				max_file_size: None,
 				salt: None,
 				columns: (0..num_columns).map(|_| Default::default()).collect(),
 				compression_threshold: HashMap::new(),

--- a/src/ref_count.rs
+++ b/src/ref_count.rs
@@ -21,6 +21,21 @@ pub const ENTRY_BYTES: usize = ENTRY_BITS as usize / 8;
 const EMPTY_CHUNK: Chunk = Chunk([0u8; CHUNK_LEN]);
 const EMPTY_ENTRIES: [Entry; CHUNK_ENTRIES] = [Entry::empty(); CHUNK_ENTRIES];
 
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(META_SIZE % CHUNK_LEN == 0);
+
+#[inline]
+fn chunk_to_file_index(mut chunk_index: u64, max_chunks: Option<u64>) -> (u64, usize) {
+	// count meta in.
+	chunk_index += (META_SIZE / CHUNK_LEN) as u64;
+
+	if let Some(i) = max_chunks {
+		(chunk_index % i, (chunk_index / i) as usize)
+	} else {
+		(chunk_index, 0)
+	}
+}
+
 #[repr(C, align(8))]
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Chunk(pub [u8; CHUNK_LEN]);
@@ -65,8 +80,10 @@ impl Entry {
 #[derive(Debug)]
 pub struct RefCountTable {
 	pub id: RefCountTableId,
-	map: RwLock<Option<memmap2::MmapMut>>,
-	path: std::path::PathBuf,
+	map: RwLock<Vec<memmap2::MmapMut>>,
+	path_base: std::path::PathBuf,
+	pub max_size: Option<usize>, // TODO store only max_chunks
+	max_chunks: Option<u64>,
 }
 
 fn total_entries(index_bits: u8) -> u64 {
@@ -101,8 +118,12 @@ impl RefCountTableId {
 		(self.0 & 0xff) as u8
 	}
 
-	pub fn file_name(&self) -> String {
-		format!("refcount_{:02}_{}", self.col(), self.index_bits())
+	pub fn file_name(&self, file_index: Option<u32>) -> String {
+		if let Some(i) = file_index {
+			format!("refcount_{:02}_{}_{:08x}", self.col(), self.index_bits(), i)
+		} else {
+			format!("refcount_{:02}_{}", self.col(), self.index_bits())
+		}
 	}
 
 	pub fn is_file_name(col: ColId, name: &str) -> bool {
@@ -142,31 +163,60 @@ impl RefCountTable {
 	pub fn open_existing(
 		path: &std::path::Path,
 		id: RefCountTableId,
+		max_size: Option<usize>,
 	) -> Result<Option<RefCountTable>> {
-		let mut path: std::path::PathBuf = path.into();
-		path.push(id.file_name());
+		let path_base: std::path::PathBuf = path.into();
+		let mut maps = Vec::new();
+		for i in 0.. {
+			let mut path = path_base.clone();
+			path.push(id.file_name(max_size.is_some().then(|| i)));
 
-		let file = match std::fs::OpenOptions::new().read(true).write(true).open(path.as_path()) {
-			Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-			Err(e) => return Err(Error::Io(e)),
-			Ok(file) => file,
-		};
+			let file = match std::fs::OpenOptions::new().read(true).write(true).open(path.as_path())
+			{
+				Err(e) if e.kind() == std::io::ErrorKind::NotFound =>
+					if i == 0 {
+						return Ok(None)
+					} else {
+						break
+					},
+				Err(e) => return Err(Error::Io(e)),
+				Ok(file) => file,
+			};
 
-		try_io!(file.set_len(file_size(id.index_bits())));
-		let mut map = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
-		madvise_random(&mut map);
-		log::debug!(target: "parity-db", "Opened existing refcount table {}", id);
-		Ok(Some(RefCountTable { id, path, map: RwLock::new(Some(map)) }))
+			try_io!(file.set_len(file_size(id.index_bits())));
+			let mut map = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
+			madvise_random(&mut map);
+			log::debug!(target: "parity-db", "Opened existing refcount table {}", id);
+			maps.push(map);
+			if max_size.is_none() {
+				break;
+			}
+		}
+		Ok(Some(RefCountTable {
+			id,
+			path_base,
+			map: RwLock::new(maps),
+			max_chunks: max_size.map(|s| (s * 1024 * 1024 / CHUNK_LEN) as u64),
+			max_size,
+		}))
 	}
 
-	pub fn create_new(path: &std::path::Path, id: RefCountTableId) -> RefCountTable {
-		let mut path: std::path::PathBuf = path.into();
-		path.push(id.file_name());
-		RefCountTable { id, path, map: RwLock::new(None) }
+	pub fn create_new(
+		path: &std::path::Path,
+		id: RefCountTableId,
+		max_size: Option<usize>,
+	) -> RefCountTable {
+		RefCountTable {
+			id,
+			path_base: path.into(),
+			map: RwLock::new(Vec::new()),
+			max_chunks: max_size.map(|s| (s * 1024 * 1024 / CHUNK_LEN) as u64),
+			max_size,
+		}
 	}
 
 	fn chunk_at(index: u64, map: &memmap2::MmapMut) -> Result<&Chunk> {
-		let offset = META_SIZE + index as usize * CHUNK_LEN;
+		let offset = index as usize * CHUNK_LEN;
 		let ptr = unsafe { &*(map[offset..offset + CHUNK_LEN].as_ptr() as *const Chunk) };
 		Ok(try_io!(Ok(ptr)))
 	}
@@ -196,7 +246,8 @@ impl RefCountTable {
 			return Ok(entry.map(|(e, sub_index)| (e.ref_count(), sub_index)))
 		}
 
-		if let Some(map) = &*self.map.read() {
+		let (chunk_index, file_index) = chunk_to_file_index(chunk_index, self.max_chunks);
+		if let Some(map) = self.map.read().get(file_index) {
 			log::trace!(target: "parity-db", "{}: Querying ref count chunk at {}", self.id, chunk_index);
 			let chunk = Self::chunk_at(chunk_index, map)?;
 			return Ok(self
@@ -212,7 +263,8 @@ impl RefCountTable {
 		{
 			return Ok(entry)
 		}
-		if let Some(map) = &*self.map.read() {
+		let (chunk_index, file_index) = chunk_to_file_index(chunk_index, self.max_chunks);
+		if let Some(map) = self.map.read().get(file_index) {
 			let chunk = Self::chunk_at(chunk_index, map)?;
 			return Ok(*Self::transmute_chunk(chunk))
 		}
@@ -220,7 +272,8 @@ impl RefCountTable {
 	}
 
 	pub fn table_entries(&self, chunk_index: u64) -> Result<[Entry; CHUNK_ENTRIES]> {
-		if let Some(map) = &*self.map.read() {
+		let (chunk_index, file_index) = chunk_to_file_index(chunk_index, self.max_chunks);
+		if let Some(map) = self.map.read().get(file_index) {
 			let chunk = Self::chunk_at(chunk_index, map)?;
 			return Ok(*Self::transmute_chunk(chunk))
 		}
@@ -299,7 +352,8 @@ impl RefCountTable {
 			return self.plan_insert_chunk(address, ref_count, chunk, sub_index, log)
 		}
 
-		if let Some(map) = &*self.map.read() {
+		let (chunk_index, file_index) = chunk_to_file_index(chunk_index, self.max_chunks);
+		if let Some(map) = self.map.read().get(file_index) {
 			let chunk = Self::chunk_at(chunk_index, map)?.clone();
 			return self.plan_insert_chunk(address, ref_count, chunk, sub_index, log)
 		}
@@ -343,7 +397,8 @@ impl RefCountTable {
 			return self.plan_remove_chunk(address, chunk, sub_index, log)
 		}
 
-		if let Some(map) = &*self.map.read() {
+		let (chunk_index, file_index) = chunk_to_file_index(chunk_index, self.max_chunks);
+		if let Some(map) = self.map.read().get(file_index) {
 			let chunk = Self::chunk_at(chunk_index, map)?.clone();
 			return self.plan_remove_chunk(address, chunk, sub_index, log)
 		}
@@ -354,23 +409,29 @@ impl RefCountTable {
 
 	pub fn enact_plan(&self, index: u64, log: &mut LogReader) -> Result<()> {
 		let mut map = self.map.upgradable_read();
-		if map.is_none() {
+		let (chunk_index, file_index) = chunk_to_file_index(index, self.max_chunks);
+		let map_len = map.len();
+		if map_len <= file_index {
 			let mut wmap = RwLockUpgradableReadGuard::upgrade(map);
-			let file = try_io!(std::fs::OpenOptions::new()
-				.write(true)
-				.read(true)
-				.create_new(true)
-				.open(self.path.as_path()));
-			log::debug!(target: "parity-db", "Created new ref count {}", self.id);
-			try_io!(file.set_len(file_size(self.id.index_bits())));
-			let mut mmap = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
-			madvise_random(&mut mmap);
-			*wmap = Some(mmap);
+			for i in map_len..file_index + 1 {
+				let mut path = self.path_base.clone();
+				path.push(self.id.file_name(self.max_size.is_some().then(|| i as u32)));
+				let file = try_io!(std::fs::OpenOptions::new()
+					.write(true)
+					.read(true)
+					.create_new(true)
+					.open(path.as_path()));
+				log::debug!(target: "parity-db", "Created new ref count {}", self.id);
+				try_io!(file.set_len(file_size(self.id.index_bits())));
+				let mut mmap = try_io!(unsafe { memmap2::MmapMut::map_mut(&file) });
+				madvise_random(&mut mmap);
+				wmap.push(mmap);
+			}
 			map = RwLockWriteGuard::downgrade_to_upgradable(wmap);
 		}
 
-		let map = map.as_ref().unwrap();
-		let offset = META_SIZE + index as usize * CHUNK_LEN;
+		let map = map.get(file_index).unwrap();
+		let offset = chunk_index as usize * CHUNK_LEN;
 		// Nasty mutable pointer cast. We do ensure that all chunks that are being written are
 		// accessed through the overlay in other threads.
 		let ptr: *mut u8 = map.as_ptr() as *mut u8;
@@ -424,15 +485,29 @@ impl RefCountTable {
 
 	pub fn drop_file(self) -> Result<()> {
 		drop(self.map);
-		try_io!(std::fs::remove_file(self.path.as_path()));
+		for i in 0.. {
+			let mut path = self.path_base.clone();
+			path.push(self.id.file_name(self.max_size.is_some().then(|| i)));
+			match std::fs::remove_file(path.as_path()) {
+				Err(e) if e.kind() == std::io::ErrorKind::NotFound => break,
+				Err(e) => return Err(Error::Io(e)),
+				Ok(()) => (),
+			};
+			if self.max_size.is_none() {
+				break;
+			}
+		}
 		log::debug!(target: "parity-db", "{}: Dropped ref count table", self.id);
 		Ok(())
 	}
 
 	pub fn flush(&self) -> Result<()> {
-		if let Some(map) = &*self.map.read() {
-			// Flush everything except stats.
-			try_io!(map.flush_range(META_SIZE, map.len() - META_SIZE));
+		// Flush everything except stats.
+		let mut start = META_SIZE;
+		let maps = self.map.read();
+		for map in maps.iter() {
+			try_io!(map.flush_range(start, map.len() - start)); // TODO not flush range when start 0
+			start = 0;
 		}
 		Ok(())
 	}
@@ -471,8 +546,10 @@ mod test {
 	fn test_find_any_entry() {
 		let table = RefCountTable {
 			id: RefCountTableId(18),
-			map: RwLock::new(None),
-			path: Default::default(),
+			map: RwLock::new(Vec::new()),
+			path_base: Default::default(),
+			max_size: None,
+			max_chunks: None,
 		};
 		let mut chunk = Chunk([0u8; CHUNK_LEN]);
 		let mut entries = [Entry::empty(); CHUNK_ENTRIES];
@@ -499,8 +576,10 @@ mod test {
 	fn test_find_entry_zero() {
 		let table = RefCountTable {
 			id: RefCountTableId(16),
-			map: RwLock::new(None),
-			path: Default::default(),
+			map: RwLock::new(Vec::new()),
+			path_base: Default::default(),
+			max_size: None,
+			max_chunks: None,
 		};
 		let mut chunk = Chunk([0u8; CHUNK_LEN]);
 		let address = Address::new(1, 1);


### PR DESCRIPTION
Been ask a few time for a size limit on parity db files.

In itself it does not really make sense, but practically I believe that many tools are pretty bad at using big files (like not even chunking them).
Still this should not be default, but can be of use.

So I try to do a quick implementation to see if it can be a good idea to have.

Got this branch that seems to run the stress test: option max_file_size is in megabyte.

A few todo to handle and test to modify (so we have some runing with multiple files) and this could be good to go (an maybe use smallvec instead of vec).

cc\ @arkpar @MattHalpinParity @PierreBesson 