### PR TITLE
feat(log): use ahash on live overlays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bench = []
 arc = []
 
 [dependencies]
+ahash = "0.8"
 blake2 = "0.10.6"
 bytes = { version = "1.7.1", optional = true }
 crc32fast = "1.4.2"

--- a/src/log.rs
+++ b/src/log.rs
@@ -13,8 +13,9 @@ use crate::{
 };
 use std::{
 	cmp::min,
-	collections::{HashMap, VecDeque},
+	collections::{hash_map::RandomState as StdBuildHasher, HashMap, VecDeque},
 	convert::TryInto,
+	hash::BuildHasher,
 	io::{ErrorKind, Read, Seek, Write},
 	sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
 };
@@ -346,11 +347,15 @@ impl<'a> LogReader<'a> {
 	}
 }
 
+/// std [`RandomState`] (SipHash) for [`LogChange`] / [`FlushedLog`] index and ref-count
+/// scratch maps — see the module comment on [`OverlayHasher`] for rationale and benchmarks.
+type LogWriterScratchBuildHasher = StdBuildHasher;
+
 #[derive(Debug)]
 pub struct LogChange {
-	local_index: HashMap<IndexTableId, IndexLogOverlay>,
+	local_index: HashMap<IndexTableId, IndexLogOverlay<LogWriterScratchBuildHasher>>,
 	local_values: HashMap<ValueTableId, ValueLogOverlayLocal>,
-	local_ref_count: HashMap<RefCountTableId, RefCountLogOverlay>,
+	local_ref_count: HashMap<RefCountTableId, RefCountLogOverlay<LogWriterScratchBuildHasher>>,
 	record_id: u64,
 	dropped_tables: Vec<IndexTableId>,
 	dropped_ref_count_tables: Vec<RefCountTableId>,
@@ -451,9 +456,9 @@ impl LogChange {
 
 #[derive(Debug)]
 struct FlushedLog {
-	index: HashMap<IndexTableId, IndexLogOverlay>,
+	index: HashMap<IndexTableId, IndexLogOverlay<LogWriterScratchBuildHasher>>,
 	values: HashMap<ValueTableId, ValueLogOverlayLocal>,
-	ref_count: HashMap<RefCountTableId, RefCountLogOverlay>,
+	ref_count: HashMap<RefCountTableId, RefCountLogOverlay<LogWriterScratchBuildHasher>>,
 	bytes: u64,
 }
 
@@ -649,45 +654,45 @@ impl std::hash::Hasher for IdentityHash {
 	}
 }
 
-// The three global overlay maps are keyed by `u64` chunk-position indices.
-// The keys originate from internal allocators (value-table free list) or
-// from the high bits of `blake2(column_key)` (index overlay) — they are not
-// user input. The cryptographic barrier against adversarial-key flooding is
-// the column-level blake2 hash that sits *above* this layer.
+// The three [`LogOverlays`] maps (index, value, ref_count) are keyed by `u64`
+// chunk-position indices, not user input — they originate from the internal
+// value-table free list or from the high bits of `blake2(column_key)` (the
+// column-level cryptographic key hash that sits above this layer).
 //
-// The default std HashMap hasher (SipHash-1-3 with a per-process random
-// seed) adds a second DoS-resistant layer here, defence-in-depth for the
-// case where some future change weakens the upstream barrier.
-// `ahash::RandomState` provides the same property — randomly seeded per
-// process so an attacker cannot precompute collisions — at ~3× lower CPU
-// cost on short keys (it uses AES-NI rounds where available). Both are
-// non-cryptographic in the formal sense; this is a "well-studied DoS hash"
-// vs "newer DoS hash" trade, not "cryptographic vs not".
+// The default std `HashMap` hasher (SipHash-1-3, per-process random seed)
+// adds a second DoS-resistant layer as defence-in-depth. `ahash::RandomState`
+// provides the same property — randomly seeded per process, so an attacker
+// cannot precompute collisions — at ~3× lower CPU on short keys, using
+// AES-NI rounds where available. Both are non-cryptographic in the formal
+// sense; this is a "well-studied DoS hash" vs "newer DoS hash" trade.
 //
-// On the warm-cache `Db::get` benchmark (8 reader threads) this gave
-// +15-22 % concurrent reader qps with no on-disk format change and no
-// semantics change. The local LogWriter scratch maps below keep their
-// existing hashers (BuildIdHash for ValueLogOverlayLocal, default for the
-// others) — they're single-threaded and short-lived.
-type ABuildHasher = ahash::RandomState;
+// On the warm-cache `Db::get` benchmark (8 reader threads, multi-column
+// substrate-shape workload) this gives +15-22 % concurrent reader qps
+// with no on-disk format change, no semantics change.
+//
+// Local [`LogChange`] / [`FlushedLog`] scratch maps keep their existing hashers
+// — they're single-threaded and short-lived: std [`RandomState`] for index and
+// ref-count ([`LogWriterScratchBuildHasher`]), identity [`BuildIdHash`] for value
+// scratch ([`ValueLogOverlayLocal`]) so WAL emission stays ordered by chunk index.
+// Only live [`LogOverlays`] use [`OverlayHasher`], via the default type parameter
+// on [`IndexLogOverlay`], [`ValueLogOverlay`], and [`RefCountLogOverlay`].
+type OverlayHasher = ahash::RandomState;
 
 #[derive(Debug, Default)]
-pub struct IndexLogOverlay {
-	pub map: HashMap<u64, (u64, u64, IndexChunk), ABuildHasher>, // index -> (record_id, modified_mask, entry)
+pub struct IndexLogOverlay<S: BuildHasher + Default = OverlayHasher> {
+	pub map: HashMap<u64, (u64, u64, IndexChunk), S>, // index -> (record_id, modified_mask, entry)
 }
 
 #[derive(Debug, Default)]
-pub struct ValueLogOverlay {
-	pub map: HashMap<u64, (u64, Vec<u8>), ABuildHasher>, // index -> (record_id, entry)
+pub struct ValueLogOverlay<S: BuildHasher + Default = OverlayHasher> {
+	pub map: HashMap<u64, (u64, Vec<u8>), S>, // index -> (record_id, entry)
 }
-#[derive(Debug, Default)]
-pub struct ValueLogOverlayLocal {
-	pub map: HashMap<u64, (u64, Vec<u8>), BuildIdHash>, // index -> (record_id, entry)
-}
+// We use identity hash for value overlay/log records so that writes to value tables are in order.
+pub type ValueLogOverlayLocal = ValueLogOverlay<BuildIdHash>;
 
 #[derive(Debug, Default)]
-pub struct RefCountLogOverlay {
-	pub map: HashMap<u64, (u64, u64, RefCountChunk), ABuildHasher>, // index -> (record_id, modified_mask, entry)
+pub struct RefCountLogOverlay<S: BuildHasher + Default = OverlayHasher> {
+	pub map: HashMap<u64, (u64, u64, RefCountChunk), S>, // index -> (record_id, modified_mask, entry)
 }
 
 #[derive(Debug)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -649,15 +649,36 @@ impl std::hash::Hasher for IdentityHash {
 	}
 }
 
+// The three global overlay maps are keyed by `u64` chunk-position indices.
+// The keys originate from internal allocators (value-table free list) or
+// from the high bits of `blake2(column_key)` (index overlay) — they are not
+// user input. The cryptographic barrier against adversarial-key flooding is
+// the column-level blake2 hash that sits *above* this layer.
+//
+// The default std HashMap hasher (SipHash-1-3 with a per-process random
+// seed) adds a second DoS-resistant layer here, defence-in-depth for the
+// case where some future change weakens the upstream barrier.
+// `ahash::RandomState` provides the same property — randomly seeded per
+// process so an attacker cannot precompute collisions — at ~3× lower CPU
+// cost on short keys (it uses AES-NI rounds where available). Both are
+// non-cryptographic in the formal sense; this is a "well-studied DoS hash"
+// vs "newer DoS hash" trade, not "cryptographic vs not".
+//
+// On the warm-cache `Db::get` benchmark (8 reader threads) this gave
+// +15-22 % concurrent reader qps with no on-disk format change and no
+// semantics change. The local LogWriter scratch maps below keep their
+// existing hashers (BuildIdHash for ValueLogOverlayLocal, default for the
+// others) — they're single-threaded and short-lived.
+type ABuildHasher = ahash::RandomState;
+
 #[derive(Debug, Default)]
 pub struct IndexLogOverlay {
-	pub map: HashMap<u64, (u64, u64, IndexChunk)>, // index -> (record_id, modified_mask, entry)
+	pub map: HashMap<u64, (u64, u64, IndexChunk), ABuildHasher>, // index -> (record_id, modified_mask, entry)
 }
 
-// We use identity hash for value overlay/log records so that writes to value tables are in order.
 #[derive(Debug, Default)]
 pub struct ValueLogOverlay {
-	pub map: HashMap<u64, (u64, Vec<u8>)>, // index -> (record_id, entry)
+	pub map: HashMap<u64, (u64, Vec<u8>), ABuildHasher>, // index -> (record_id, entry)
 }
 #[derive(Debug, Default)]
 pub struct ValueLogOverlayLocal {
@@ -666,7 +687,7 @@ pub struct ValueLogOverlayLocal {
 
 #[derive(Debug, Default)]
 pub struct RefCountLogOverlay {
-	pub map: HashMap<u64, (u64, u64, RefCountChunk)>, // index -> (record_id, modified_mask, entry)
+	pub map: HashMap<u64, (u64, u64, RefCountChunk), ABuildHasher>, // index -> (record_id, modified_mask, entry)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Background

The three LogOverlay maps (index, value, ref_count) are keyed by u64 chunk-position indices, not user input — they originate from the internal value-table free list or from the high bits of blake2(column_key) (the column-level cryptographic key hash that sits above this layer).

The default std HashMap hasher (SipHash-1-3, per-process random seed) adds a second DoS-resistant layer as defence-in-depth. ahash::RandomState provides the same property — randomly seeded per process, so an attacker cannot precompute collisions — at ~3× lower CPU on short keys, using AES-NI rounds where available. Both are non-cryptographic in the formal sense; this is a "well-studied DoS hash" vs "newer DoS hash" trade.

On the warm-cache Db::get benchmark (8 reader threads, multi-column substrate-shape workload) this gives +15-22 % concurrent reader qps with no on-disk format change, no semantics change, and 36/36 lib tests passing.

The local LogWriter scratch maps keep their existing hashers — they're single-threaded and short-lived.

## Benchmarking

We made an experiment with live network sync with following results:

```
Validator	Start (UTC)	Finish (UTC, extrap.)	Duration	Avg rate
validator-04	16:41:51	18:03:38	1h 21m 47s	34.1 bps
validator-05	16:41:52	17:51:33	1h 09m 40s	40.0 bps
val-05 finished 12m 06s earlier than val-04.
```

<img width="1684" height="1121" alt="sync_progress" src="https://github.com/user-attachments/assets/c7911118-1390-47d7-80da-b8995e957512" />

## What this PR does

**File: `src/log.rs`**

- Import `std::collections::hash_map::RandomState` (as `StdBuildHasher`) and `std::hash::BuildHasher`.
- Add `LogWriterScratchBuildHasher = StdBuildHasher` for writer-local index and ref-count scratch maps, with a short doc note.
- Rename the `ahash` map builder alias to `OverlayHasher` (`ahash::RandomState`).
- Make `IndexLogOverlay`, `ValueLogOverlay`, and `RefCountLogOverlay` generic over `S: BuildHasher + Default`, defaulting to `OverlayHasher` (unchanged for `LogOverlays`).
- Use `IndexLogOverlay<LogWriterScratchBuildHasher>` and `RefCountLogOverlay<LogWriterScratchBuildHasher>` inside `LogChange` and `FlushedLog`.
- Replace the standalone `ValueLogOverlayLocal` struct with `pub type ValueLogOverlayLocal = ValueLogOverlay<BuildIdHash>`.
- Extend the module comments so they match the background above and describe which hasher is used where (live overlays vs scratch maps).
