### PR TITLE
fix: deadlock between commit worker and cleanup worker

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1293,8 +1293,11 @@ impl DbInner {
 				let max_logs = if self.options.sync_data { MAX_LOG_FILES } else { KEEP_LOGS };
 				let dirty_logs = self.log.num_dirty_logs();
 				if !validation_mode {
-					while self.log.num_dirty_logs() > max_logs {
+					while !self.shutdown.load(Ordering::Relaxed) &&
+						self.log.num_dirty_logs() > max_logs
+					{
 						log::debug!(target: "parity-db", "Waiting for log cleanup. Queued: {}", dirty_logs);
+						self.cleanup_worker_wait.signal();
 						self.cleanup_queue_wait.wait();
 					}
 				}


### PR DESCRIPTION
Commit worker parks on log-cleanup cap while the cleanup worker is never signalled during a sustained enactment backlog. This turns out to be a deadlock under a sustained write burst where log enactment falls behind log flushing.

I managed to fix it by waking the cleanup worker before parking. See the test in this [commit](https://github.com/ChainSafe/forest/commit/b2505f700b315ba0d63bc9947a71a60d9821b88f). This was supposed to be a temporary workaround, alas, it couldn't be even temporary as the entire thing got stuck at the drop. With this fix it passed 8/8 times.

I leaned heavily on Fable to get to this small fix, and my ParityDb-internals-Fu is weak, so there might be something not accounted for. Full CC write-up [here](https://gist.github.com/LesnyRumcajs/4e99bbcfa0c5f9d9448fd12d032a25a3).

I don't really see a good way to work around this client-side, so I'd appreciate some :eyes: on this PR and if all looks good, a small patch release. Otherwise I'd have to fork and put some throwaway fork crate on crates.io.